### PR TITLE
[FIX] medical_prescription: Require order ID

### DIFF
--- a/medical_prescription/models/medical_prescription_order_line.py
+++ b/medical_prescription/models/medical_prescription_order_line.py
@@ -13,10 +13,15 @@ class MedicalPrescriptionOrderLine(models.Model):
 
     prescription_order_id = fields.Many2one(
         comodel_name='medical.prescription.order',
-        string='Prescription Order')
+        string='Prescription Order',
+        required=True,
+    )
     medical_medication_id = fields.Many2one(
-        comodel_name='medical.patient.medication', string='Medication',
-        required=True, ondelete='cascade')
+        comodel_name='medical.patient.medication',
+        string='Medication',
+        required=True,
+        ondelete='cascade',
+    )
     is_substitutable = fields.Boolean()
     qty = fields.Float(string='Quantity')
 

--- a/medical_prescription/tests/test_medical_prescription_order_line.py
+++ b/medical_prescription/tests/test_medical_prescription_order_line.py
@@ -2,6 +2,7 @@
 # Copyright 2016 LasLabs Inc.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from psycopg2 import IntegrityError
 from openerp.tests.common import TransactionCase
 
 
@@ -43,3 +44,18 @@ class TestMedicalPrescriptionOrderLine(TransactionCase):
             len(recs),
             'Length of recs (%d) not equal to 3' % (len(recs)),
         )
+
+    def test_prescription_order_id_required(self):
+        test_medicament = self.env['medical.medicament'].create({
+            'name': 'Test Medicament',
+            'drug_form_id': self.env.ref('medical_medicament.AEM').id,
+        })
+        test_patient = self.env['medical.patient'].create({
+            'name': 'Test Patient',
+        })
+
+        with self.assertRaisesRegexp(IntegrityError, 'prescription_order_id'):
+            self.line_model.create({
+                'medicament_id': test_medicament.id,
+                'patient_id': test_patient.id,
+            })


### PR DESCRIPTION
- Require all prescription order lines to have a corresponding prescription order. Creating a prescription order line without an order can cause issues.
