### PR TITLE
[9.0][ADD] medical_prescription_sale_stock_us: Time logic

### DIFF
--- a/medical_prescription_sale_stock_us/__openerp__.py
+++ b/medical_prescription_sale_stock_us/__openerp__.py
@@ -16,6 +16,7 @@
     ],
     'data': [
         'views/procurement_order_view.xml',
+        'views/res_company_view.xml',
     ],
     "website": "https://laslabs.com",
     "license": "AGPL-3",

--- a/medical_prescription_sale_stock_us/views/res_company_view.xml
+++ b/medical_prescription_sale_stock_us/views/res_company_view.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+    Copyright 2016 LasLabs Inc.
+    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+-->
+
+<odoo>
+    <record id="view_company_form" model="ir.ui.view">
+        <field name="name">Company Form View - Prescription Refill Threshold</field>
+        <field name="model">res.company</field>
+        <field name="inherit_id" ref="base.view_company_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//page[@name='configuration']" position="inside">
+                <group name="medical_group" string="Medical">
+                    <field name="medical_prescription_refill_threshold"/>
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
- Modify logic in _compute_dispense_remain to factor in all completed
  dispensings, rather than just the last one, and change the associated fields
  accordingly
- Add guards to _compute_dispense_remain to prevent issues associated with
  missing medical.prescription.order.line fields
- Modify logic in _compute_can_dispense_and_qty to include the estimated
  number of unused units calculated in _compute_dispense_remain when determining
  how much more can be dispensed
- Add logic to _compute_can_dispense_and_qty that will not allow more to be
  dispensed if the estimated number of unused units exceeds the refill threshold
  associated with the prescription order line
- Add the medical_prescription_refill_threshold field to the res.company form
  view for user manipulation
