### PR TITLE
[FIX] medical_medication: Missing dependency

### DIFF
--- a/medical_medication/__openerp__.py
+++ b/medical_medication/__openerp__.py
@@ -12,6 +12,7 @@
     'depends': [
         'medical',
         'medical_patient_disease',
+        'medical_physician',
         'medical_medicament',
     ],
     'summary': 'Introduce medication notion into the medical addons',


### PR DESCRIPTION
- Add missing dependency on medical_physician. Its absence was preventing the
  module from installing.
