### PR TITLE
[FIX] medical_medication: Wrong attribute in view

### DIFF
--- a/medical_medication/views/medical_patient_medication_view.xml
+++ b/medical_medication/views/medical_patient_medication_view.xml
@@ -70,7 +70,7 @@
                         </group>
                     </group>
                 </xpath>
-                <xpath expr="//notebook" postition="inside">
+                <xpath expr="//notebook" position="inside">
                     <page name="adverse_reaction" string="Adverse Reaction">
                         <field name="adverse_reaction" nolabel="1"/>
                     </page>


### PR DESCRIPTION
- Update the medical_patient_medication_form_view, which included the
  misspelled attribute 'postition' in place of 'position'. This was not causing
  any functional issues due to default behavior but could have done so in the
  future.
