### PR TITLE
[9.0][FIX] medical_prescription_us: Add check for negative refill_qty_original

### DIFF
--- a/medical_prescription_sale_stock/models/sale_order_line.py
+++ b/medical_prescription_sale_stock/models/sale_order_line.py
@@ -82,16 +82,10 @@ class SaleOrderLine(models.Model):
         if self.env.context.get('__rx_force__'):
             return True
         for rec_id in self:
-            if not rec_id.product_id.is_medicament:
-                continue
-            medicament_id = self.env['medical.medicament'].search([
-                ('product_id', '=', rec_id.product_id.id),
-            ],
-                limit=1,
-            )
-            conditions = [medicament_id.is_prescription]
-            if rec_id.state in ['draft', 'sent']:
-                conditions.append(rec_id.prescription_order_line_id)
+            conditions = [
+                rec_id.product_id.is_medicament,
+                rec_id.prescription_order_line_id,
+            ]
             if not all(conditions):
                 continue
             rx_line = rec_id.prescription_order_line_id

--- a/medical_prescription_sale_stock/tests/test_all.py
+++ b/medical_prescription_sale_stock/tests/test_all.py
@@ -297,3 +297,14 @@ class TestAll(TransactionCase):
                 [expect.id], res
             )
         )
+
+    def test_check_can_dispense_no_order_lines(self):
+        """ Test Validations skipped if no prescription lines present """
+        order_id = self._new_rx_order()
+        try:
+            order_id.order_line[0].prescription_order_line_id = None
+            self.assertTrue(True)
+        except ValidationError:
+            self.fail(
+                'Should skip validations if no rx_line.'
+            )

--- a/medical_prescription_us/models/medical_prescription_order_line.py
+++ b/medical_prescription_us/models/medical_prescription_order_line.py
@@ -3,8 +3,8 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from dateutil.relativedelta import relativedelta
-
-from openerp import fields, models, api
+from openerp.exceptions import ValidationError
+from openerp import fields, models, api, _
 
 
 # @TODO: Abstract control codes into core, add months till expire
@@ -56,3 +56,12 @@ class MedicalPrescriptionOrderLine(models.Model):
             except KeyError:
                 pass
         return super(MedicalPrescriptionOrderLine, self).create(vals)
+
+    @api.multi
+    @api.constrains('refill_qty_original')
+    def _check_refill_qty_original(self):
+        for rec_id in self:
+            if rec_id.refill_qty_original < 0:
+                raise ValidationError(_(
+                    'Refill quantity cannot be less than 0.'
+                ))

--- a/medical_prescription_us/tests/__init__.py
+++ b/medical_prescription_us/tests/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import test_medical_prescription_order_line

--- a/medical_prescription_us/tests/test_medical_prescription_order_line.py
+++ b/medical_prescription_us/tests/test_medical_prescription_order_line.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp.tests.common import TransactionCase
+from openerp.exceptions import ValidationError
+
+
+class TestMedicalPrescriptionOrderLine(TransactionCase):
+
+    def setUp(self):
+        super(TestMedicalPrescriptionOrderLine, self).setUp()
+        self.order_line_1 = self.env.ref(
+            'medical_prescription.' +
+            'medical_prescription_order_line_patient_1_order_1_line_1'
+        )
+
+    def test_check_refill_qty_original(self):
+        """ Test refill_qty_original cannot be less than 0 """
+        with self.assertRaises(ValidationError):
+            self.order_line_1.refill_qty_original = -1


### PR DESCRIPTION
- Add _check_refill_qty_original to prescription_order_line
- Add respective test case

@obulkin I fixed the negative refill issue in medical_prescription_us, however as per [LABS-300](https://tickets.laslabs.com/browse/LABS-300), I'm not quite sure what you're describing in medical_prescription_sale_stock_us. I see a possible weak point in [medical_prescription_sale_stock](https://github.com/laslabs/vertical-medical/blob/release/9.0/medical_prescription_sale_stock/models/sale_order_line.py#L114). Do you mind elaborating more on what the issue is?

Thanks :)
