### PR TITLE
[IMP][9.0] medical_prescription: Add active computation on Rx

### DIFF
--- a/medical_prescription/models/medical_prescription_order.py
+++ b/medical_prescription/models/medical_prescription_order.py
@@ -47,9 +47,19 @@ class MedicalPrescriptionOrder(models.Model):
         string='Prescription Date',
         default=lambda s: fields.Datetime.now(),
     )
+    active = fields.Boolean(
+        compute='_compute_active',
+    )
 
     @api.model
     def _default_name(self):
         return self.env['ir.sequence'].next_by_code(
             'medical.prescription.order',
         )
+
+    @api.multi
+    def _compute_active(self):
+        for rec_id in self:
+            rec_id.active = any(
+                rec_id.prescription_order_line_ids.mapped('active')
+            )

--- a/medical_prescription/tests/__init__.py
+++ b/medical_prescription/tests/__init__.py
@@ -2,4 +2,5 @@
 # Copyright 2016 LasLabs Inc.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from . import test_medical_prescription_order
 from . import test_medical_prescription_order_line

--- a/medical_prescription/tests/test_medical_prescription_order.py
+++ b/medical_prescription/tests/test_medical_prescription_order.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.tests.common import TransactionCase
+
+
+class TestMedicalPrescriptionOrder(TransactionCase):
+
+    def setUp(self):
+        super(TestMedicalPrescriptionOrder, self).setUp()
+
+        self.line_model = self.env['medical.prescription.order.line']
+        self.line = self.env.ref(
+            'medical_prescription.'
+            'medical_prescription_order_line_patient_1_order_1_line_1'
+        )
+
+    def test_active_true(self):
+        """ It should set active to true when rx line is active """
+        self.assertTrue(
+            self.line.prescription_order_id.active
+        )
+
+    def test_active_false(self):
+        """ It should set active to true when rx line is active """
+        order = self.line.prescription_order_id
+        for line in order.prescription_order_line_ids:
+            line.active = False
+        self.assertFalse(
+            self.line.prescription_order_id.active
+        )

--- a/medical_prescription/tests/test_medical_prescription_order_line.py
+++ b/medical_prescription/tests/test_medical_prescription_order_line.py
@@ -13,7 +13,7 @@ class TestMedicalPrescriptionOrderLine(TransactionCase):
 
         self.line_model = self.env['medical.prescription.order.line']
         self.line = self.env.ref(
-            'medical_prescription.' +
+            'medical_prescription.'
             'medical_prescription_order_line_patient_1_order_1_line_1'
         )
 


### PR DESCRIPTION
* Add computation for prescription to be inactive when all lines are

Direct backport of #20 