### PR TITLE
[FIX] partner_medical_medication: New partner patient IDs

### DIFF
--- a/partner_medical_medication/models/res_partner.py
+++ b/partner_medical_medication/models/res_partner.py
@@ -18,7 +18,10 @@ class ResPartner(models.Model):
     @api.depends('child_ids')
     def _compute_medical_patient_ids(self):
         for record in self:
-            patients = self.env['medical.patient'].search([
-                ('partner_id', 'child_of', record.id),
-            ])
-            record.medical_patient_ids = [(6, 0, patients.ids)]
+            if record.id:
+                patients = self.env['medical.patient'].search([
+                    ('partner_id', 'child_of', record.id),
+                ])
+                record.medical_patient_ids = [(6, 0, patients.ids)]
+            else:
+                record.medical_patient_ids = [(6, 0, [])]

--- a/partner_medical_medication/tests/test_res_partner.py
+++ b/partner_medical_medication/tests/test_res_partner.py
@@ -32,3 +32,13 @@ class TestResPartner(TransactionCase):
             partner.medical_patient_ids,
             patient + child_patient + grandchild_patient,
         )
+
+    def test_medical_patient_ids_not_persisted(self):
+        '''It should return empty patient recordset if partner not in DB yet'''
+        test_partner = self.env['res.partner'].new()
+
+        self.assertFalse(test_partner.medical_patient_ids)
+        self.assertEqual(
+            test_partner.medical_patient_ids._name,
+            'medical.patient',
+        )


### PR DESCRIPTION
* Add logic to the method used to compute the `medical_patient_ids` field on
`res.partner` to prevent errors when the partner record is still being created
and does not have a proper ID yet (e.g. when a user is on the form view for a
new record)