### PR TITLE
[FIX][9.0] medical_prescription: Store active field

### DIFF
--- a/medical_prescription/models/medical_prescription_order.py
+++ b/medical_prescription/models/medical_prescription_order.py
@@ -64,6 +64,9 @@ class MedicalPrescriptionOrder(models.Model):
                  )
     def _compute_active(self):
         for rec_id in self:
+            if not rec_id.prescription_order_line_ids:
+                rec_id.active = True
+                continue
             rec_id.active = any(
                 rec_id.prescription_order_line_ids.mapped('active')
             )

--- a/medical_prescription/models/medical_prescription_order.py
+++ b/medical_prescription/models/medical_prescription_order.py
@@ -49,6 +49,7 @@ class MedicalPrescriptionOrder(models.Model):
     )
     active = fields.Boolean(
         compute='_compute_active',
+        store=True,
     )
 
     @api.model
@@ -58,6 +59,9 @@ class MedicalPrescriptionOrder(models.Model):
         )
 
     @api.multi
+    @api.depends('prescription_order_line_ids',
+                 'prescription_order_line_ids.active',
+                 )
     def _compute_active(self):
         for rec_id in self:
             rec_id.active = any(


### PR DESCRIPTION
Failing build introduced in #24. False positive due to issue that is now fixed in MQT; fail can be see in Runbot 9.0 & on #35 

* Set active to store and add depends to method in order to allow searching