### PR TITLE
[FIX][10.0] medical_prescription_sale_stock: Allow OTC w/ Rx

### DIFF
--- a/sale_stock_medical_prescription/models/sale_order_line.py
+++ b/sale_stock_medical_prescription/models/sale_order_line.py
@@ -26,6 +26,8 @@ class SaleOrderLine(models.Model):
     def _compute_dispense_qty(self):
         for rec_id in self:
             rx_line = rec_id.prescription_order_line_id
+            if not rx_line:
+                return
             if rec_id.product_uom == rx_line.dispense_uom_id:
                 rec_id.dispense_qty = rec_id.product_uom_qty
             else:

--- a/sale_stock_medical_prescription/tests/test_all.py
+++ b/sale_stock_medical_prescription/tests/test_all.py
@@ -125,6 +125,7 @@ class TestAll(TransactionCase):
         if new_resources:
             self._new_resources()
         order_id = self.env['sale.order'].create(self.order_vals)
+        order_id.order_line[0].prescription_order_line_id = False
         return order_id
 
     def _new_procurement(self, order_line_id):
@@ -256,6 +257,12 @@ class TestAll(TransactionCase):
         order_id = self._new_rx_order()
         self.assertEqual(
             1, order_id.order_line[0].dispense_qty,
+        )
+
+    def test_sale_line_compute_dispense_qty_otc(self):
+        order_id = self._new_order()
+        self.assertFalse(
+            order_id.order_line[0].dispense_qty,
         )
 
     def test_sale_line_check_product(self):


### PR DESCRIPTION
* Skip dispense qty computation if no rx line is avail on sale order line

This is candidate for quick-merge pending approval of:
- [x] #46 

And obviously CI 🍏 