### PR TITLE
[10.0][IMP] medical_prescription_stage: Switch to new kanban module

### DIFF
--- a/medical_prescription_state/views/medical_prescription_order.xml
+++ b/medical_prescription_state/views/medical_prescription_order.xml
@@ -12,6 +12,7 @@
         <field name="model">medical.prescription.order</field>
         <field name="inherit_id" ref="base_kanban_stage.base_kanban_abstract_view_kanban" />
         <field name="mode">primary</field>
+        <field name="priority" eval="99" />
         <field name="arch" type="xml">
             <xpath expr="//div[@name='card_header']">
                 <span t-if="record.patient_id.raw_value">

--- a/medical_prescription_state/views/medical_prescription_order_line.xml
+++ b/medical_prescription_state/views/medical_prescription_order_line.xml
@@ -12,6 +12,7 @@
         <field name="model">medical.prescription.order.line</field>
         <field name="inherit_id" ref="base_kanban_stage.base_kanban_abstract_view_kanban" />
         <field name="mode">primary</field>
+        <field name="priority" eval="99" />
         <field name="arch" type="xml">
             <xpath expr="//div[@name='card_header']" position="replace">
                 <strong>
@@ -57,5 +58,4 @@
         <field name="view_mode">kanban,tree,form</field>
         <field name="view_id" ref="medical_prescription_order_line_kanban_view" />
     </record>
-
 </odoo>


### PR DESCRIPTION
Forward port of #70. Uses OCA/server-tools#681, we will need to update the oca_depends when merged

* Switch from `medical_base_kanban` to `base_kanban_stage`
* Add requirements to oca_requirements.txt