### PR TITLE
[FIX] oca_dependencies: Add PR note for dependency

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,2 +1,3 @@
 partner-contact
+# Waiting on merge of OCA/website#270
 website https://github.com/laslabs/website.git release/10.0/website_field_autocomplete_related


### PR DESCRIPTION
* Add PR note for website_field_autocomplete_related in oca_dependencies to fix LasLabs#76

cc @jcdrubay 