### PR TITLE
[10.0][FIX] medical_medication: Fix form view

### DIFF
--- a/medical_medication/views/medical_patient_medication_view.xml
+++ b/medical_medication/views/medical_patient_medication_view.xml
@@ -65,18 +65,16 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='pathology_id']" position="replace">
                 <group>
-                    <group>
-                        <field name="medication_template_id"
-                               domain="[('medicament_id','=', medicament_id)]" />
-                        <field name="date_start_treatment" />
-                        <field name="physician_id" />
-                    </group>
-                    <group>
-                        <field name="patient_id" />
-                        <field name="date_stop_treatment" />
-                        <field name="is_discontinued" />
-                        <field name="is_course_complete" />
-                    </group>
+                    <field name="medication_template_id"
+                           domain="[('medicament_id','=', medicament_id)]" />
+                    <field name="date_start_treatment" />
+                    <field name="physician_id" />
+                </group>
+                <group>
+                    <field name="patient_id" />
+                    <field name="date_stop_treatment" />
+                    <field name="is_discontinued" />
+                    <field name="is_course_complete" />
                 </group>
             </xpath>
             <xpath expr="//notebook" position="inside">


### PR DESCRIPTION
* Remove extra group from form view that was causing collapsed columns as noted in LasLabs#91

Before:

![image](https://cloud.githubusercontent.com/assets/7397578/21905502/7b395eb0-d8bc-11e6-8c00-7b2ed638ff52.png)


After:

![image](https://cloud.githubusercontent.com/assets/7397578/21905486/6e32eb3c-d8bc-11e6-9283-a33fccb88b29.png)
