### PR TITLE
[IMP] GH #91 - Add medicament onchange to Rx Line

### DIFF
--- a/medical_prescription/models/medical_prescription_order_line.py
+++ b/medical_prescription/models/medical_prescription_order_line.py
@@ -53,3 +53,8 @@ class MedicalPrescriptionOrderLine(models.Model):
 
         recs = self.search(domain + args, limit=limit)
         return recs.name_get()
+
+    @api.onchange('medical_medication_id')
+    def _onchange_medical_medication_id(self):
+        self.dispense_uom_id = \
+            self.medical_medication_id.medicament_id.uom_id.id

--- a/medical_prescription/tests/test_medical_prescription_order_line.py
+++ b/medical_prescription/tests/test_medical_prescription_order_line.py
@@ -118,6 +118,7 @@ class TestMedicalPrescriptionOrderLine(TransactionCase):
             'medical_prescription.medical_prescription_order_order_line_2'
         )
         self.rx_line_1.medical_medication_id = rx_line2.medical_medication_id
+        self.rx_line_1._onchange_medical_medication_id()
         self.assertEquals(
             self.dispense_uom_id,
             self.rx_line_1.medical_medication_id.medicament_id.uom_id.id,

--- a/medical_prescription/tests/test_medical_prescription_order_line.py
+++ b/medical_prescription/tests/test_medical_prescription_order_line.py
@@ -114,8 +114,9 @@ class TestMedicalPrescriptionOrderLine(TransactionCase):
         )
 
     def test_onchange_medical_medication_id(self):
+        '''The medical medicament changes when the medication changes'''
         rx_line2 = self.env.ref(
-            'medical_prescription.medical_prescription_order_order_line_2'
+            'medical_prescription.medical_prescription_order_order_line_5'
         )
         self.rx_line_1.medical_medication_id = rx_line2.medical_medication_id
         self.rx_line_1._onchange_medical_medication_id()

--- a/medical_prescription/tests/test_medical_prescription_order_line.py
+++ b/medical_prescription/tests/test_medical_prescription_order_line.py
@@ -20,6 +20,8 @@ class TestMedicalPrescriptionOrderLine(TransactionCase):
             'medical_prescription.'
             'medical_prescription_order_order_line_1'
         )
+        self.dispense_uom_id = \
+            self.rx_line_1.medical_medication_id.medicament_id.uom_id.id
 
     def test_default_name(self):
         """ Test name added to rx_line as default """
@@ -109,4 +111,14 @@ class TestMedicalPrescriptionOrderLine(TransactionCase):
         exp = sorted(set(exp))
         self.assertEquals(
             res, exp,
+        )
+
+    def test_onchange_medical_medication_id(self):
+        rx_line2 = self.env.ref(
+            'medical_prescription.medical_prescription_order_order_line_2'
+        )
+        self.rx_line_1.medical_medication_id = rx_line2.medical_medication_id
+        self.assertEquals(
+            self.dispense_uom_id,
+            self.rx_line_1.medical_medication_id.medicament_id.uom_id.id,
         )


### PR DESCRIPTION
Changes the dispense_uom_id in medical.prescription.order.line when the medical_medication_id changes.

Fixes #91