### PR TITLE
[9.0][IMP] oca_dependencies: Server tools - Kanban

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,2 +1,2 @@
 website https://github.com/LasLabs/website.git release/9.0/website_field_autocomplete_related
-server-tools https://github.com/LasLabs/server-tools.git feature/9.0/LABS-134-create-medical_base_stage-object
+server-tools


### PR DESCRIPTION
I will merge this if CIs pass, it is to fix a breaking build now that the dependency is merged and branch deleted.

* Switch to production server tools now that the Kanban base is merged