### PR TITLE
[10.0][IMP] Centralize entity image encode/resize

### DIFF
--- a/medical/__manifest__.py
+++ b/medical/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     'name': 'Odoo Medical',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'Medical',
     'depends': [
         'product',

--- a/medical/models/medical_abstract_entity.py
+++ b/medical/models/medical_abstract_entity.py
@@ -151,7 +151,7 @@ class MedicalAbstractEntity(models.AbstractModel):
     def _create_vals(self, vals):
         """ Override this in child classes in order to add default values. """
         if self._allow_image_create(vals):
-            vals['image'] = self._get_default_image(vals)
+            vals['image'] = self._get_default_image_encoded(vals)
         return vals
 
     @api.model_cr_context

--- a/medical/models/medical_patient.py
+++ b/medical/models/medical_patient.py
@@ -103,9 +103,7 @@ class MedicalPatient(models.Model):
 
     @api.model_cr_context
     def _get_default_image(self, vals):
-        res = super(MedicalPatient, self)._get_default_image(vals)
-        if res:
-            return res
+        super(MedicalPatient, self)._get_default_image(vals)
         img_path = get_module_resource(
             'medical', 'static/src/img', 'patient-avatar.png',
         )

--- a/medical/models/medical_patient.py
+++ b/medical/models/medical_patient.py
@@ -6,7 +6,7 @@
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
 
-from odoo import _, api, fields, models, tools
+from odoo import _, api, fields, models
 from odoo.modules import get_module_resource
 from odoo.exceptions import ValidationError
 
@@ -101,7 +101,7 @@ class MedicalPatient(models.Model):
         })
         return vals
 
-    @api.model
+    @api.model_cr_context
     def _get_default_image(self, vals):
         res = super(MedicalPatient, self)._get_default_image(vals)
         if res:
@@ -110,5 +110,4 @@ class MedicalPatient(models.Model):
             'medical', 'static/src/img', 'patient-avatar.png',
         )
         with open(img_path, 'r') as image:
-            base64_image = image.read().encode('base64')
-            return tools.image_resize_image_big(base64_image)
+            return image

--- a/medical/models/medical_patient.py
+++ b/medical/models/medical_patient.py
@@ -102,10 +102,8 @@ class MedicalPatient(models.Model):
         return vals
 
     @api.model_cr_context
-    def _get_default_image(self, vals):
-        super(MedicalPatient, self)._get_default_image(vals)
-        img_path = get_module_resource(
+    def _get_default_image_path(self, vals):
+        super(MedicalPatient, self)._get_default_image_path(vals)
+        return get_module_resource(
             'medical', 'static/src/img', 'patient-avatar.png',
         )
-        with open(img_path, 'r') as image:
-            return image

--- a/medical/tests/test_medical_patient.py
+++ b/medical/tests/test_medical_patient.py
@@ -108,7 +108,7 @@ class TestMedicalPatient(TransactionCase):
             len(partner.patient_ids), 1,
         )
 
-    def test_create_vals_default_image(self):
+    def test_create_vals_get_default_image_encoded(self):
         """ It should get the default image for entity on create. """
         Patient = self.env['medical.patient'].with_context(
             __image_create_allow=True,
@@ -117,10 +117,10 @@ class TestMedicalPatient(TransactionCase):
         patient = Patient.create(vals)
         self.assertTrue(patient.image)
 
-    def test_get_default_image(self):
+    def test_get_default_image_encoded(self):
         """ It should return the default image for the entity. """
         Patient = self.env['medical.patient']
-        image = Patient._get_default_image({})
+        image = Patient._get_default_image_encoded({})
         self.assertTrue(image)
 
     def test_allow_image_create_no_test(self):

--- a/medical_center/models/medical_center.py
+++ b/medical_center/models/medical_center.py
@@ -20,10 +20,8 @@ class MedicalCenter(models.Model):
         return super(MedicalCenter, self)._create_vals(vals)
 
     @api.model
-    def _get_default_image(self, vals):
-        super(MedicalCenter, self)._get_default_image(vals)
-        img_path = get_module_resource(
+    def _get_default_image_path(self, vals):
+        super(MedicalCenter, self)._get_default_image_path(vals)
+        return get_module_resource(
             'medical_center', 'static/src/img', 'medical-center-avatar.png',
         )
-        with open(img_path, 'r') as image:
-            return image

--- a/medical_center/models/medical_center.py
+++ b/medical_center/models/medical_center.py
@@ -21,9 +21,7 @@ class MedicalCenter(models.Model):
 
     @api.model
     def _get_default_image(self, vals):
-        res = super(MedicalCenter, self)._get_default_image(vals)
-        if not res:
-            return res
+        super(MedicalCenter, self)._get_default_image(vals)
         img_path = get_module_resource(
             'medical_center', 'static/src/img', 'medical-center-avatar.png',
         )

--- a/medical_center/models/medical_center.py
+++ b/medical_center/models/medical_center.py
@@ -2,7 +2,7 @@
 # Copyright 2016 LasLabs Inc.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import api, models, tools
+from odoo import api, models
 from odoo.modules import get_module_resource
 
 
@@ -28,5 +28,4 @@ class MedicalCenter(models.Model):
             'medical_center', 'static/src/img', 'medical-center-avatar.png',
         )
         with open(img_path, 'r') as image:
-            base64_image = image.read().encode('base64')
-        return tools.image_resize_image_big(base64_image)
+            return image

--- a/medical_pharmacy/models/medical_pharmacist.py
+++ b/medical_pharmacy/models/medical_pharmacist.py
@@ -21,9 +21,7 @@ class MedicalPharmacist(models.Model):
 
     @api.model
     def _get_default_image(self, vals):
-        res = super(MedicalPharmacist, self)._get_default_image(vals)
-        if not res:
-            return res
+        super(MedicalPharmacist, self)._get_default_image(vals)
         img_path = 'pharmacist-%s-avatar.png' % vals.get('gender')
         img_path = get_module_resource(
             'medical_pharmacy', 'static/src/img', img_path,

--- a/medical_pharmacy/models/medical_pharmacist.py
+++ b/medical_pharmacy/models/medical_pharmacist.py
@@ -20,8 +20,8 @@ class MedicalPharmacist(models.Model):
         return super(MedicalPharmacist, self)._create_vals(vals)
 
     @api.model
-    def _get_default_image(self, vals):
-        super(MedicalPharmacist, self)._get_default_image(vals)
+    def _get_default_image_path(self, vals):
+        super(MedicalPharmacist, self)._get_default_image_path(vals)
         img_path = 'pharmacist-%s-avatar.png' % vals.get('gender')
         img_path = get_module_resource(
             'medical_pharmacy', 'static/src/img', img_path,
@@ -32,5 +32,4 @@ class MedicalPharmacist(models.Model):
                 'static/src/img',
                 'pharmacist-female-avatar.png',
             )
-        with open(img_path, 'r') as image:
-            return image
+        return img_path

--- a/medical_pharmacy/models/medical_pharmacist.py
+++ b/medical_pharmacy/models/medical_pharmacist.py
@@ -2,7 +2,7 @@
 # © 2016 LasLabs Inc.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import api, models, tools
+from odoo import api, models
 from odoo.modules import get_module_resource
 
 
@@ -35,5 +35,4 @@ class MedicalPharmacist(models.Model):
                 'pharmacist-female-avatar.png',
             )
         with open(img_path, 'r') as image:
-            base64_image = image.read().encode('base64')
-        return tools.image_resize_image_big(base64_image)
+            return image

--- a/medical_physician/models/medical_physician.py
+++ b/medical_physician/models/medical_physician.py
@@ -51,9 +51,7 @@ class MedicalPhysician(models.Model):
 
     @api.model
     def _get_default_image(self, vals):
-        res = super(MedicalPhysician, self)._get_default_image(vals)
-        if not res:
-            return res
+        super(MedicalPhysician, self)._get_default_image(vals)
         img_path = 'physician-%s-avatar.png' % vals.get('gender')
         img_path = get_module_resource(
             'medical_pharmacy', 'static/src/img', img_path,

--- a/medical_physician/models/medical_physician.py
+++ b/medical_physician/models/medical_physician.py
@@ -50,8 +50,8 @@ class MedicalPhysician(models.Model):
         return super(MedicalPhysician, self)._create_vals(vals)
 
     @api.model
-    def _get_default_image(self, vals):
-        super(MedicalPhysician, self)._get_default_image(vals)
+    def _get_default_image_path(self, vals):
+        super(MedicalPhysician, self)._get_default_image_path(vals)
         img_path = 'physician-%s-avatar.png' % vals.get('gender')
         img_path = get_module_resource(
             'medical_pharmacy', 'static/src/img', img_path,
@@ -62,5 +62,4 @@ class MedicalPhysician(models.Model):
                 'static/src/img',
                 'physician-male-avatar.png',
             )
-        with open(img_path, 'r') as image:
-            return image
+        return img_path

--- a/medical_physician/models/medical_physician.py
+++ b/medical_physician/models/medical_physician.py
@@ -2,7 +2,7 @@
 # © 2016 LasLabs Inc.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import api, fields, models, tools
+from odoo import api, fields, models
 from odoo.modules import get_module_resource
 
 
@@ -65,5 +65,4 @@ class MedicalPhysician(models.Model):
                 'physician-male-avatar.png',
             )
         with open(img_path, 'r') as image:
-            base64_image = image.read().encode('base64')
-        return tools.image_resize_image_big(base64_image)
+            return image


### PR DESCRIPTION
@jcdrubay - is this something like what you were thinking in https://github.com/OCA/vertical-medical/pull/159#discussion_r96153055? I went the file handler route instead of an image path because I could see it being beneficial allowing sources other than local disk. This cut down on the code savings though unfortunately 😦 