### PR TITLE
[FIX][10.0] Demo data and readme fixes

### DIFF
--- a/medical/README.rst
+++ b/medical/README.rst
@@ -87,7 +87,7 @@ Bug Tracker
 Bugs are tracked on `GitHub Issues
 <https://github.com/OCA/vertical-medical/issues>`_. In case of trouble, please
 check there if your issue has already been reported. If you spotted it first,
-help us smashing it by providing a detailed and welcomed feedback.
+help us smash it by providing detailed and welcomed feedback.
 
 Credits
 =======

--- a/medical_medicament/README.rst
+++ b/medical_medicament/README.rst
@@ -27,7 +27,7 @@ Bug Tracker
 Bugs are tracked on `GitHub Issues
 <https://github.com/OCA/vertical-medical/issues>`_. In case of trouble, please
 check there if your issue has already been reported. If you spotted it first,
-help us smashing it by providing a detailed and welcomed feedback.
+help us smash it by providing detailed and welcomed feedback.
 
 Credits
 =======

--- a/medical_medicament/demo/medical_medicament_demo.xml
+++ b/medical_medicament/demo/medical_medicament_demo.xml
@@ -6,16 +6,15 @@
 
     <record id="product_product_advil_1" model="product.product">
         <field name="name">Advil</field>
-        <field name="uom_id" ref="product.product_uom_gram" />
-        <field name="uom_po_id" ref="product.product_uom_gram" />
-        <field name="weight">22.6796</field>
-        <field name="volume">0.008</field>
+        <field name="uom_id" ref="product.product_uom_unit" />
+        <field name="uom_po_id" ref="product.product_uom_unit" />
+        <field name="weight">0.0002</field>
         <field name="categ_id" ref="product.product_category_5" />
         <field name="type">consu</field>
-        <field name="description_sale">Advil 200 Capsules 200mg</field>
+        <field name="description_sale">Advil Capsule 200mg</field>
         <field name="pricelist_id" ref="product.list0" />
-        <field name="standard_price">15.25</field>
-        <field name="list_price">24.99</field>
+        <field name="standard_price">0.06</field>
+        <field name="list_price">0.12</field>
         <field name="currency_id" ref="base.USD" />
         <field name="default_code">ADV</field>
     </record>
@@ -33,20 +32,19 @@
 
     <record id="product_product_advil_2" model="product.product">
         <field name="name">Advil Extra Strength</field>
-        <field name="uom_id" ref="product.product_uom_gram" />
-        <field name="uom_po_id" ref="product.product_uom_gram" />
-        <field name="weight">15</field>
-        <field name="volume">0.0033</field>
+        <field name="uom_id" ref="product.product_uom_unit" />
+        <field name="uom_po_id" ref="product.product_uom_unit" />
+        <field name="weight">0.0004</field>
         <field name="categ_id" ref="product.product_category_5" />
         <field name="type">consu</field>
-        <field name="description_sale">Advil Extra Strength 24 Capsules 400mg</field>
+        <field name="description_sale">Advil Extra Strength Capsule 400mg</field>
         <field name="pricelist_id" ref="product.list0" />
-        <field name="standard_price">4.50</field>
-        <field name="list_price">10.99</field>
+        <field name="standard_price">0.35</field>
+        <field name="list_price">0.46</field>
         <field name="currency_id" ref="base.USD" />
         <field name="default_code">ADV-XSTNGTH</field>
     </record>
-    
+
     <record id="medical_medicament_advil_2" model="medical.medicament">
         <field name="name">Advil Extra Strength</field>
         <field name="type">consu</field>
@@ -58,5 +56,5 @@
         <field name="product_id" ref="medical_medicament.product_product_advil_2" />
         <field name="pregnancy_category">d</field>
     </record>
-        
+
 </odoo>

--- a/medical_medication/README.rst
+++ b/medical_medication/README.rst
@@ -24,7 +24,7 @@ Bug Tracker
 Bugs are tracked on `GitHub Issues
 <https://github.com/OCA/vertical-medical/issues>`_. In case of trouble, please
 check there if your issue has already been reported. If you spotted it first,
-help us smashing it by providing a detailed and welcomed feedback.
+help us smash it by providing detailed and welcomed feedback.
 
 Credits
 =======

--- a/medical_medication/__init__.py
+++ b/medical_medication/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import models
+from .hooks import _inherit_medication_template_vals

--- a/medical_medication/__manifest__.py
+++ b/medical_medication/__manifest__.py
@@ -13,6 +13,7 @@
     "license": "AGPL-3",
     "application": False,
     "installable": True,
+    "post_init_hook": "_inherit_medication_template_vals",
     "depends": [
         "medical_patient_disease",
         "medical_medicament",

--- a/medical_medication/demo/medical_medicament_demo.xml
+++ b/medical_medication/demo/medical_medicament_demo.xml
@@ -6,22 +6,22 @@
 
     <record id="product_product_truvada_1" model="product.product">
         <field name="name">Truvada</field>
-        <field name="uom_id" ref="product.product_uom_gram" />
-        <field name="uom_po_id" ref="product.product_uom_gram" />
-        <field name="weight">15</field>
+        <field name="uom_id" ref="product.product_uom_unit" />
+        <field name="uom_po_id" ref="product.product_uom_unit" />
+        <field name="weight">0.0003</field>
         <field name="categ_id" ref="product.product_category_5" />
         <field name="type">consu</field>
-        <field name="description_sale">Truvada 30 Capsules 300mg</field>
+        <field name="description_sale">Truvada Capsule 300mg</field>
         <field name="pricelist_id" ref="product.list0" />
-        <field name="standard_price">60.25</field>
-        <field name="list_price">99.99</field>
+        <field name="standard_price">2.50</field>
+        <field name="list_price">3.33</field>
         <field name="currency_id" ref="base.USD" />
         <field name="default_code">TRUV</field>
     </record>
 
     <record id="medical_medicament_truvada_1" model="medical.medicament">
         <field name="name">Truvada</field>
-        <field name="drug_form_id" ref="medical_medicament.TAB" />
+        <field name="drug_form_id" ref="medical_medicament.CAP" />
         <field name="strength">0.3</field>
         <field name="strength_uom_id" ref="product.product_uom_gram" />
         <field name="drug_route_id" ref="medical_medicament.route_34" />
@@ -31,15 +31,15 @@
 
     <record id="product_product_aralen_1" model="product.product">
         <field name="name">Aralen</field>
-        <field name="uom_id" ref="product.product_uom_gram" />
-        <field name="uom_po_id" ref="product.product_uom_gram" />
-        <field name="weight">17</field>
+        <field name="uom_id" ref="product.product_uom_unit" />
+        <field name="uom_po_id" ref="product.product_uom_unit" />
+        <field name="weight">0.00025</field>
         <field name="categ_id" ref="product.product_category_5" />
         <field name="type">consu</field>
-        <field name="description_sale">Aralen 60 Tablets 250mg</field>
+        <field name="description_sale">Aralen Tablet 250mg</field>
         <field name="pricelist_id" ref="product.list0" />
-        <field name="standard_price">45.25</field>
-        <field name="list_price">67.19</field>
+        <field name="standard_price">0.60</field>
+        <field name="list_price">1.12</field>
         <field name="currency_id" ref="base.USD" />
         <field name="default_code">ARLN</field>
     </record>

--- a/medical_medication/demo/medical_patient_medication_demo.xml
+++ b/medical_medication/demo/medical_patient_medication_demo.xml
@@ -7,7 +7,7 @@
     <record id="medical_medication_template_template_1" model="medical.medication.template">
         <field name="medicament_id" ref="medical_medicament.medical_medicament_advil_1" />
         <field name="quantity">2</field>
-        <field name="dose_uom_id" ref="medical_medication.product_uom_mg" />
+        <field name="dose_uom_id" ref="product.product_uom_unit" />
         <field name="frequency">2</field>
         <field name="frequency_uom_id" ref="medical_medication.product_uom_hour" />
         <field name="duration">1</field>
@@ -25,7 +25,7 @@
     <record id="medical_medication_template_template_2" model="medical.medication.template">
         <field name="medicament_id" ref="medical_medicament.medical_medicament_advil_2" />
         <field name="quantity">1</field>
-        <field name="dose_uom_id" ref="medical_medication.product_uom_mg" />
+        <field name="dose_uom_id" ref="product.product_uom_unit" />
         <field name="pathology_id" ref="medical_medication.medical_pathology_pathology_4" />
         <field name="duration">1</field>
         <field name="duration_uom_id" ref="medical_medication.product_uom_day" />
@@ -42,7 +42,7 @@
     <record id="medical_medication_template_template_3" model="medical.medication.template">
         <field name="medicament_id" ref="medical_medicament.medical_medicament_advil_1" />
         <field name="quantity">2</field>
-        <field name="dose_uom_id" ref="medical_medication.product_uom_mg" />
+        <field name="dose_uom_id" ref="product.product_uom_unit" />
         <field name="duration">1</field>
         <field name="duration_uom_id" ref="medical_medication.product_uom_hour" />
     </record>
@@ -61,7 +61,7 @@
         <field name="frequency_prn">True</field>
         <field name="medication_dosage_id" ref="medical_medication.420449005" />
         <field name="quantity">200</field>
-        <field name="dose_uom_id" ref="medical_medication.product_uom_mg" />
+        <field name="dose_uom_id" ref="product.product_uom_unit" />
         <field name="suggested_administration_hours">10</field>
         <field name="duration">1</field>
         <field name="duration_uom_id" ref="medical_medication.product_uom_day" />
@@ -84,7 +84,7 @@
         <field name="frequency_uom_id" ref="medical_medication.product_uom_hour" />
         <field name="medication_dosage_id" ref="medical_medication.307470009" />
         <field name="quantity">1</field>
-        <field name="dose_uom_id" ref="medical_medication.product_uom_mg" />
+        <field name="dose_uom_id" ref="product.product_uom_unit" />
         <field name="suggested_administration_hours">12</field>
     </record>
 
@@ -105,7 +105,7 @@
         <field name="frequency_uom_id" ref="medical_medication.product_uom_hour" />
         <field name="medication_dosage_id" ref="medical_medication.420449005" />
         <field name="quantity">1</field>
-        <field name="dose_uom_id" ref="medical_medication.product_uom_mg" />
+        <field name="dose_uom_id" ref="product.product_uom_unit" />
         <field name="suggested_administration_hours">8</field>
     </record>
 
@@ -116,5 +116,5 @@
         <field name="physician_id" ref="medical_physician.medical_physician_physician_1" />
         <field name="date_start_treatment">2016-12-02</field>
     </record>
-        
+
 </odoo>

--- a/medical_medication/hooks.py
+++ b/medical_medication/hooks.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, SUPERUSER_ID
+
+
+def _inherit_medication_template_vals(cr, registry):
+    with cr.savepoint():
+        env = api.Environment(cr, SUPERUSER_ID, {})
+        medication_model = env['medical.patient.medication']
+        medications = medication_model.search([])
+
+        for medication in medications:
+            medication.onchange_template_id()

--- a/medical_medication/tests/__init__.py
+++ b/medical_medication/tests/__init__.py
@@ -2,6 +2,7 @@
 # Copyright 2016 LasLabs Inc.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from . import test_hooks
 from . import test_abstract_medical_medication
 from . import test_medical_medication_dosage
 from . import test_medical_medication_template

--- a/medical_medication/tests/test_hooks.py
+++ b/medical_medication/tests/test_hooks.py
@@ -1,15 +1,14 @@
 # -*- coding: utf-8 -*-
-# Copyright 2015 ACSONE SA/NV
 # Copyright 2016 LasLabs Inc.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo.tests.common import TransactionCase
 
 
-class TestAbstractMedicalMedication(TransactionCase):
+class TestHooks(TransactionCase):
 
     def setUp(self):
-        super(TestAbstractMedicalMedication, self).setUp()
+        super(TestHooks, self).setUp()
         self.medication_6 = self.env.ref(
             'medical_medication.medical_patient_medication_medication_6'
         )
@@ -17,12 +16,8 @@ class TestAbstractMedicalMedication(TransactionCase):
             'medical_medication.medical_medication_template_template_6'
         )
 
-    def test_onchange_template_id(self):
+    def test_post_init_hook_magic_columns(self):
         """ Test template vals and medication vals are set the same """
-
-        # Ensures test is independent from post_init_hook
-        self.medication_template_6.quantity = 200
-
         comparison_keys = [
             'medicament_id',
             'quantity',
@@ -35,7 +30,6 @@ class TestAbstractMedicalMedication(TransactionCase):
             'medication_dosage_id',
             'suggested_administration_hours',
         ]
-        self.medication_6.onchange_template_id()
         for k in comparison_keys:
             t_value = getattr(self.medication_6, k)
             m_value = getattr(self.medication_template_6, k)

--- a/medical_pathology/README.rst
+++ b/medical_pathology/README.rst
@@ -54,7 +54,7 @@ Bug Tracker
 Bugs are tracked on `GitHub Issues
 <https://github.com/OCA/vertical-medical/issues>`_. In case of trouble, please
 check there if your issue has already been reported. If you spotted it first,
-help us smashing it by providing a detailed and welcomed feedback.
+help us smash it by providing detailed and welcomed feedback.
 
 Credits
 =======

--- a/medical_patient_disease/README.rst
+++ b/medical_patient_disease/README.rst
@@ -21,7 +21,7 @@ Bug Tracker
 Bugs are tracked on `GitHub Issues
 <https://github.com/OCA/vertical-medical/issues>`_. In case of trouble, please
 check there if your issue has already been reported. If you spotted it first,
-help us smashing it by providing a detailed and welcomed feedback.
+help us smash it by providing detailed and welcomed feedback.
 
 Credits
 =======

--- a/medical_patient_disease_allergy/README.rst
+++ b/medical_patient_disease_allergy/README.rst
@@ -21,7 +21,7 @@ Bug Tracker
 Bugs are tracked on `GitHub Issues
 <https://github.com/OCA/vertical-medical/issues>`_. In case of trouble, please
 check there if your issue has already been reported. If you spotted it first,
-help us smashing it by providing a detailed and welcomed feedback.
+help us smash it by providing detailed and welcomed feedback.
 
 Credits
 =======

--- a/medical_patient_dob/README.rst
+++ b/medical_patient_dob/README.rst
@@ -24,7 +24,7 @@ Bug Tracker
 Bugs are tracked on `GitHub Issues
 <https://github.com/OCA/vertical-medical/issues>`_. In case of trouble, please
 check there if your issue has already been reported. If you spotted it first,
-help us smashing it by providing a detailed and welcomed feedback.
+help us smash it by providing detailed and welcomed feedback.
 
 Credits
 =======

--- a/medical_pharmacy/demo/medical_pharmacy_demo.xml
+++ b/medical_pharmacy/demo/medical_pharmacy_demo.xml
@@ -12,7 +12,7 @@
         <field name="country_id" ref="base.us" />
         <field name="phone">+1-888-888-8888</field>
         <field name="email">email@example.com</field>
-        <field name="state_id" ref="base.state_us_3" />
+        <field name="state_id" ref="base.state_us_23" />
     </record>
 
     <record id="medical_pharmacy_1" model="medical.pharmacy">

--- a/medical_physician/README.rst
+++ b/medical_physician/README.rst
@@ -24,7 +24,7 @@ Bug Tracker
 Bugs are tracked on `GitHub Issues
 <https://github.com/OCA/vertical-medical/issues>`_. In case of trouble, please
 check there if your issue has already been reported. If you spotted it first,
-help us smashing it by providing a detailed and welcomed feedback.
+help us smash it by providing detailed and welcomed feedback.
 
 Credits
 =======

--- a/medical_physician/demo/medical_physician.xml
+++ b/medical_physician/demo/medical_physician.xml
@@ -55,11 +55,11 @@
         <field name="ref">576-01-3001</field>
         <field name="gender">female</field>
     </record>
-  
+
     <record id="medical_physician_physician_3" model="medical.physician">
         <field name="partner_id" ref="medical_physician.res_partner_physician_3" />
         <field name="specialty_id" ref="medical_specialty_gp" />
         <field name="info">General practitioner, supplier</field>
     </record>
-        
+
 </odoo>

--- a/medical_prescription/README.rst
+++ b/medical_prescription/README.rst
@@ -22,7 +22,7 @@ Bug Tracker
 Bugs are tracked on `GitHub Issues
 <https://github.com/OCA/vertical-medical/issues>`_. In case of trouble, please
 check there if your issue has already been reported. If you spotted it first,
-help us smashing it by providing a detailed and welcomed feedback.
+help us smash it by providing detailed and welcomed feedback.
 
 Credits
 =======

--- a/medical_prescription/demo/medical_pharmacy_demo.xml
+++ b/medical_prescription/demo/medical_pharmacy_demo.xml
@@ -12,7 +12,7 @@
         <field name="country_id" ref="base.us" />
         <field name="phone">+1 (702) 455-2447</field>
         <field name="email">pharmacy_2@example.com</field>
-        <field name="state_id" ref="base.state_us_3" />
+        <field name="state_id" ref="base.state_us_23" />
     </record>
 
     <record id="medical_pharmacy_2" model="medical.pharmacy">

--- a/medical_prescription/models/medical_prescription_order_line.py
+++ b/medical_prescription/models/medical_prescription_order_line.py
@@ -7,6 +7,7 @@ from odoo import api, fields, models
 
 class MedicalPrescriptionOrderLine(models.Model):
     _name = 'medical.prescription.order.line'
+    _description = 'Medical Prescription Order Line'
     _inherit = ['abstract.medical.medication']
     _inherits = {'medical.patient.medication': 'medical_medication_id'}
     _rec_name = 'medical_medication_id'

--- a/medical_prescription/tests/test_medical_prescription_order_line.py
+++ b/medical_prescription/tests/test_medical_prescription_order_line.py
@@ -20,47 +20,85 @@ class TestMedicalPrescriptionOrderLine(TransactionCase):
     def test_name_search_medicament_name(self):
         """ Test returns line_ids matching medicament name """
         res = self.line_model.name_search(self.advil_1.name)
-        res_len = len(res)
+        exp = self.line_model.search([(
+            'medicament_id.product_id.name',
+            'ilike',
+            self.advil_1.name,
+        )]).name_get()
+
+        res = sorted(set(res))
+        exp = sorted(set(exp))
         self.assertEquals(
-            res_len, 4,
+            res, exp,
         )
 
     def test_name_search_medicament_strength(self):
         """ Test returns line_ids matching medicament strength """
         res = self.line_model.name_search(self.advil_1.strength)
-        res_len = len(res)
+        exp = self.line_model.search([(
+            'medicament_id.strength',
+            'ilike',
+            self.advil_1.strength,
+        )]).name_get()
+
+        res = sorted(set(res))
+        exp = sorted(set(exp))
         self.assertEquals(
-            res_len, 4,
+            res, exp,
         )
 
     def test_name_search_medicament_uom_name(self):
         """ Test returns line_ids matching medicament strength uom """
         res = self.line_model.name_search(self.advil_1.strength_uom_id.name)
-        res_len = len(res)
+        exp = self.line_model.search([(
+            'medicament_id.strength_uom_id.name',
+            'ilike',
+            self.advil_1.strength_uom_id.name,
+        )]).name_get()
+
+        res = sorted(set(res))
+        exp = sorted(set(exp))
         self.assertEquals(
-            res_len, 6,
+            res, exp,
         )
 
     def test_name_search_medicament_drug_form_code(self):
         """ Test returns line_ids matching medicament drug form code """
         res = self.line_model.name_search(self.advil_1.drug_form_id.code)
-        res_len = len(res)
+        exp = self.line_model.search([(
+            'medicament_id.drug_form_id.code',
+            'ilike',
+            self.advil_1.drug_form_id.code,
+        )]).name_get()
+
+        res = sorted(set(res))
+        exp = sorted(set(exp))
         self.assertEquals(
-            res_len, 4,
+            res, exp,
         )
 
     def test_name_search_patient_name(self):
         """ Test returns line_ids belonging to specified patient """
         res = self.line_model.name_search(self.patient_1.name)
-        res_len = len(res)
+        exp = self.line_model.search([(
+            'patient_id.name',
+            'ilike',
+            self.patient_1.name,
+        )]).name_get()
+
+        res = sorted(set(res))
+        exp = sorted(set(exp))
         self.assertEquals(
-            res_len, 2,
+            res, exp,
         )
 
-    def test_name_search_none(self):
+    def test_name_search_no_params(self):
         """ Test returns all line_ids if blank search params """
         res = self.line_model.name_search()
-        res_len = len(res)
+        exp = self.line_model.search([]).name_get()
+
+        res = sorted(set(res))
+        exp = sorted(set(exp))
         self.assertEquals(
-            res_len, 6,
+            res, exp,
         )


### PR DESCRIPTION
#### This PR includes several fixes to demo data and readmes in the first set of oca migrated modules
* Readme
    *  _help us smashing . . . providing a detailed and welcomed feedback_ **=>** _help us smash . . . providing detailed and welcomed feedback_
* Add post_init_hook so medication demo data inherits vals from medication_template demo data vals
* Fix volatile tests in medical_prescription
* Various fixes to medicaments
* Correct wrong US states in pharmacies

#### Current thoughts
* @LasLabs/admins the majority of medication demo data comes from medical_medication, however modules further down the dependency chain add new medications, such as sale_medical_prescription. Since those modules do not have a post_init_hook, prescriptons in those modules will not have dosage data and other attributes found in medication template. Do you think, instead of post_init I should add @api.depends to [abstract_medical_medication](https://github.com/LasLabs/vertical-medical/blob/release/10.0/medical_medication/models/abstract_medical_medication.py#L16), or is it not a big deal?

#### modules affected or checked with no changes done

- medical
- medical_medicament
- medical_physician
- medical_pharmacy
- medical_pathology
- medical_patient_disease
- medical_patient_disease_allergy
- medical_medication
- medical_prescription
- medical_patient_dob 