### PR TITLE
[10.0][IMP] medical_prescription_state: Add default states

### DIFF
--- a/medical_medication/models/medical_patient_medication.py
+++ b/medical_medication/models/medical_patient_medication.py
@@ -47,6 +47,7 @@ class MedicalPatientMedication(models.Model):
              ' discontinued',
     )
     date_start_treatment = fields.Datetime(
+        default=lambda s: fields.Datetime.now(),
         help='When the patient began taking this medication',
     )
     date_stop_treatment = fields.Datetime(

--- a/medical_prescription_state/__init__.py
+++ b/medical_prescription_state/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import models
+from .hooks import post_init_hook

--- a/medical_prescription_state/__manifest__.py
+++ b/medical_prescription_state/__manifest__.py
@@ -3,20 +3,21 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {
-    'name': 'Medical Prescription Order States',
-    'version': '10.0.1.0.0',
-    'author': "LasLabs, Odoo Community Association (OCA)",
-    'category': 'Medical',
-    'depends': [
-        'base_kanban_stage',
-        'medical_prescription',
+    "name": "Medical Prescription Order States",
+    "version": "10.0.1.0.0",
+    "author": "LasLabs, Odoo Community Association (OCA)",
+    "category": "Medical",
+    "website": "https://laslabs.com",
+    "license": "AGPL-3",
+    "depends": [
+        "base_kanban_stage",
+        "medical_prescription",
     ],
-    'website': 'http://github.com/oca/vertical-medical',
-    'license': 'AGPL-3',
-    'data': [
-        'views/medical_prescription_order.xml',
-        'views/medical_prescription_order_line.xml',
+    "data": [
+        "views/medical_prescription_order.xml",
+        "views/medical_prescription_order_line.xml",
+        "data/base_kanban_stage.xml",
     ],
-    'installable': True,
-    'auto_install': False,
+    "installable": True,
+    "auto_install": False,
 }

--- a/medical_prescription_state/__manifest__.py
+++ b/medical_prescription_state/__manifest__.py
@@ -9,6 +9,7 @@
     "category": "Medical",
     "website": "https://laslabs.com",
     "license": "AGPL-3",
+    "post_init_hook": "post_init_hook",
     "depends": [
         "base_kanban_stage",
         "medical_prescription",

--- a/medical_prescription_state/data/base_kanban_stage.xml
+++ b/medical_prescription_state/data/base_kanban_stage.xml
@@ -13,7 +13,6 @@
         <field name="sequence" eval="1" />
         <field name="fold" eval="False" />
         <field name="res_model_id" ref="medical_prescription.model_medical_prescription_order" />
-        <field name="state">draft</field>
     </record>
 
     <record id="prescription_order_state_started" model="base.kanban.stage">
@@ -22,7 +21,6 @@
         <field name="sequence" eval="2" />
         <field name="fold" eval="False" />
         <field name="res_model_id" ref="medical_prescription.model_medical_prescription_order" />
-        <field name="state">open</field>
     </record>
 
     <record id="prescription_order_state_pv1" model="base.kanban.stage">
@@ -31,7 +29,6 @@
         <field name="sequence" eval="3" />
         <field name="fold" eval="False" />
         <field name="res_model_id" ref="medical_prescription.model_medical_prescription_order" />
-        <field name="state">pending</field>
     </record>
 
     <record id="prescription_order_state_verified" model="base.kanban.stage">
@@ -40,7 +37,6 @@
         <field name="sequence" eval="4" />
         <field name="fold" eval="True" />
         <field name="res_model_id" ref="medical_prescription.model_medical_prescription_order" />
-        <field name="state">done</field>
     </record>
 
     <record id="prescription_order_state_cancelled" model="base.kanban.stage">
@@ -49,7 +45,6 @@
         <field name="sequence" eval="5" />
         <field name="fold" eval="True" />
         <field name="res_model_id" ref="medical_prescription.model_medical_prescription_order" />
-        <field name="state">cancelled</field>
     </record>
 
     <!-- Prescription Order Line State -->
@@ -60,7 +55,6 @@
         <field name="sequence" eval="1" />
         <field name="fold" eval="True" />
         <field name="res_model_id" ref="medical_prescription.model_medical_prescription_order_line" />
-        <field name="state">draft</field>
     </record>
 
     <record id="prescription_order_line_state_hold" model="base.kanban.stage">
@@ -69,7 +63,6 @@
         <field name="sequence" eval="2" />
         <field name="fold" eval="True" />
         <field name="res_model_id" ref="medical_prescription.model_medical_prescription_order_line" />
-        <field name="state">draft</field>
     </record>
 
     <record id="prescription_order_line_state_ordered" model="base.kanban.stage">
@@ -78,7 +71,6 @@
         <field name="sequence" eval="3" />
         <field name="fold" eval="False" />
         <field name="res_model_id" ref="medical_prescription.model_medical_prescription_order_line" />
-        <field name="state">open</field>
     </record>
 
     <record id="prescription_order_line_state_pv2" model="base.kanban.stage">
@@ -87,7 +79,6 @@
         <field name="sequence" eval="4" />
         <field name="fold" eval="False" />
         <field name="res_model_id" ref="medical_prescription.model_medical_prescription_order_line" />
-        <field name="state">pending</field>
     </record>
 
     <record id="prescription_order_line_state_dur" model="base.kanban.stage">
@@ -96,7 +87,6 @@
         <field name="sequence" eval="5" />
         <field name="fold" eval="False" />
         <field name="res_model_id" ref="medical_prescription.model_medical_prescription_order_line" />
-        <field name="state">pending</field>
     </record>
 
     <record id="prescription_order_line_state_complete" model="base.kanban.stage">
@@ -105,7 +95,6 @@
         <field name="sequence" eval="6" />
         <field name="fold" eval="False" />
         <field name="res_model_id" ref="medical_prescription.model_medical_prescription_order_line" />
-        <field name="state">done</field>
     </record>
 
 </odoo>

--- a/medical_prescription_state/data/base_kanban_stage.xml
+++ b/medical_prescription_state/data/base_kanban_stage.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2017 LasLabs Inc.
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo noupdate="1">
+
+
+    <!-- Prescription Order States -->
+
+    <record id="prescription_order_state_unverified" model="base.kanban.stage">
+        <field name="name">Unverified</field>
+        <field name="description">This is the starting point for all incoming prescriptions.</field>
+        <field name="sequence" eval="1" />
+        <field name="fold" eval="False" />
+        <field name="res_model" ref="medical.prescription.order" />
+        <field name="state">draft</field>
+    </record>
+
+    <record id="prescription_order_state_started" model="base.kanban.stage">
+        <field name="name">In Progress</field>
+        <field name="description">These prescriptions are in the process of having their information validated.</field>
+        <field name="sequence" eval="2" />
+        <field name="fold" eval="False" />
+        <field name="res_model" ref="medical.prescription.order" />
+        <field name="state">open</field>
+    </record>
+
+    <record id="prescription_order_state_pv1" model="base.kanban.stage">
+        <field name="name">PV1</field>
+        <field name="description">These prescriptions are in PV1 (Prescription Verification Stage 1).</field>
+        <field name="sequence" eval="3" />
+        <field name="fold" eval="False" />
+        <field name="res_model" ref="medical.prescription.order" />
+        <field name="state">pending</field>
+    </record>
+
+    <record id="prescription_order_state_verified" model="base.kanban.stage">
+        <field name="name">Verified</field>
+        <field name="description">These prescriptions have passed initial verification.</field>
+        <field name="sequence" eval="4" />
+        <field name="fold" eval="True" />
+        <field name="res_model" ref="medical.prescription.order" />
+        <field name="state">done</field>
+    </record>
+
+    <record id="prescription_order_state_cancelled" model="base.kanban.stage">
+        <field name="name">Cancelled</field>
+        <field name="description">These prescriptions have been cancelled, or are otherwise invalid.</field>
+        <field name="sequence" eval="5" />
+        <field name="fold" eval="True" />
+        <field name="res_model" ref="medical.prescription.order" />
+        <field name="state">cancelled</field>
+    </record>
+
+    <!-- Prescription Order Line State -->
+
+    <record id="prescription_order_line_state_unverified" model="base.kanban.stage">
+        <field name="name">Unverified</field>
+        <field name="description">These prescription lines are awaiting validation at the prescription level (PV1).</field>
+        <field name="sequence" eval="1" />
+        <field name="fold" eval="True" />
+        <field name="res_model" ref="medical.prescription.order.line" />
+        <field name="state">draft</field>
+    </record>
+
+    <record id="prescription_order_line_state_hold" model="base.kanban.stage">
+        <field name="name">Hold</field>
+        <field name="description">These prescription lines have passed initial validation (PV1), and are awaiting their first matched sale order.</field>
+        <field name="sequence" eval="2" />
+        <field name="fold" eval="True" />
+        <field name="res_model" ref="medical.prescription.order.line" />
+        <field name="state">draft</field>
+    </record>
+
+    <record id="prescription_order_line_state_ordered" model="base.kanban.stage">
+        <field name="name">Ordered</field>
+        <field name="description">These prescription lines have passed initial validation (PV1), and have at least one matched sale order.</field>
+        <field name="sequence" eval="3" />
+        <field name="fold" eval="False" />
+        <field name="res_model" ref="medical.prescription.order.line" />
+        <field name="state">open</field>
+    </record>
+
+    <record id="prescription_order_line_state_pv2" model="base.kanban.stage">
+        <field name="name">PV2</field>
+        <field name="description">These prescription lines are ready for RPH verification for dispense.</field>
+        <field name="sequence" eval="4" />
+        <field name="fold" eval="False" />
+        <field name="res_model" ref="medical.prescription.order.line" />
+        <field name="state">pending</field>
+    </record>
+
+    <record id="prescription_order_line_state_dur" model="base.kanban.stage">
+        <field name="name">DUR</field>
+        <field name="description">These prescription lines have failed DUR check and require additional review/action.</field>
+        <field name="sequence" eval="5" />
+        <field name="fold" eval="False" />
+        <field name="res_model" ref="medical.prescription.order.line" />
+        <field name="state">pending</field>
+    </record>
+
+    <record id="prescription_order_line_state_complete" model="base.kanban.stage">
+        <field name="name">Complete</field>
+        <field name="description">These prescription lines have passed PV2 &amp; DUR.</field>
+        <field name="sequence" eval="6" />
+        <field name="fold" eval="False" />
+        <field name="res_model" ref="medical.prescription.order.line" />
+        <field name="state">done</field>
+    </record>
+
+</odoo>

--- a/medical_prescription_state/data/base_kanban_stage.xml
+++ b/medical_prescription_state/data/base_kanban_stage.xml
@@ -12,7 +12,7 @@
         <field name="description">This is the starting point for all incoming prescriptions.</field>
         <field name="sequence" eval="1" />
         <field name="fold" eval="False" />
-        <field name="res_model" ref="medical.prescription.order" />
+        <field name="res_model_id" ref="medical_prescription.model_medical_prescription_order" />
         <field name="state">draft</field>
     </record>
 
@@ -21,7 +21,7 @@
         <field name="description">These prescriptions are in the process of having their information validated.</field>
         <field name="sequence" eval="2" />
         <field name="fold" eval="False" />
-        <field name="res_model" ref="medical.prescription.order" />
+        <field name="res_model_id" ref="medical_prescription.model_medical_prescription_order" />
         <field name="state">open</field>
     </record>
 
@@ -30,7 +30,7 @@
         <field name="description">These prescriptions are in PV1 (Prescription Verification Stage 1).</field>
         <field name="sequence" eval="3" />
         <field name="fold" eval="False" />
-        <field name="res_model" ref="medical.prescription.order" />
+        <field name="res_model_id" ref="medical_prescription.model_medical_prescription_order" />
         <field name="state">pending</field>
     </record>
 
@@ -39,7 +39,7 @@
         <field name="description">These prescriptions have passed initial verification.</field>
         <field name="sequence" eval="4" />
         <field name="fold" eval="True" />
-        <field name="res_model" ref="medical.prescription.order" />
+        <field name="res_model_id" ref="medical_prescription.model_medical_prescription_order" />
         <field name="state">done</field>
     </record>
 
@@ -48,7 +48,7 @@
         <field name="description">These prescriptions have been cancelled, or are otherwise invalid.</field>
         <field name="sequence" eval="5" />
         <field name="fold" eval="True" />
-        <field name="res_model" ref="medical.prescription.order" />
+        <field name="res_model_id" ref="medical_prescription.model_medical_prescription_order" />
         <field name="state">cancelled</field>
     </record>
 
@@ -59,7 +59,7 @@
         <field name="description">These prescription lines are awaiting validation at the prescription level (PV1).</field>
         <field name="sequence" eval="1" />
         <field name="fold" eval="True" />
-        <field name="res_model" ref="medical.prescription.order.line" />
+        <field name="res_model_id" ref="medical_prescription.model_medical_prescription_order_line" />
         <field name="state">draft</field>
     </record>
 
@@ -68,7 +68,7 @@
         <field name="description">These prescription lines have passed initial validation (PV1), and are awaiting their first matched sale order.</field>
         <field name="sequence" eval="2" />
         <field name="fold" eval="True" />
-        <field name="res_model" ref="medical.prescription.order.line" />
+        <field name="res_model_id" ref="medical_prescription.model_medical_prescription_order_line" />
         <field name="state">draft</field>
     </record>
 
@@ -77,7 +77,7 @@
         <field name="description">These prescription lines have passed initial validation (PV1), and have at least one matched sale order.</field>
         <field name="sequence" eval="3" />
         <field name="fold" eval="False" />
-        <field name="res_model" ref="medical.prescription.order.line" />
+        <field name="res_model_id" ref="medical_prescription.model_medical_prescription_order_line" />
         <field name="state">open</field>
     </record>
 
@@ -86,7 +86,7 @@
         <field name="description">These prescription lines are ready for RPH verification for dispense.</field>
         <field name="sequence" eval="4" />
         <field name="fold" eval="False" />
-        <field name="res_model" ref="medical.prescription.order.line" />
+        <field name="res_model_id" ref="medical_prescription.model_medical_prescription_order_line" />
         <field name="state">pending</field>
     </record>
 
@@ -95,7 +95,7 @@
         <field name="description">These prescription lines have failed DUR check and require additional review/action.</field>
         <field name="sequence" eval="5" />
         <field name="fold" eval="False" />
-        <field name="res_model" ref="medical.prescription.order.line" />
+        <field name="res_model_id" ref="medical_prescription.model_medical_prescription_order_line" />
         <field name="state">pending</field>
     </record>
 
@@ -104,7 +104,7 @@
         <field name="description">These prescription lines have passed PV2 &amp; DUR.</field>
         <field name="sequence" eval="6" />
         <field name="fold" eval="False" />
-        <field name="res_model" ref="medical.prescription.order.line" />
+        <field name="res_model_id" ref="medical_prescription.model_medical_prescription_order_line" />
         <field name="state">done</field>
     </record>
 

--- a/medical_prescription_state/hooks.py
+++ b/medical_prescription_state/hooks.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, SUPERUSER_ID
+
+
+def post_init_hook(cr, registry):
+    """Loaded after installing the module.
+    This module's DB modifications will be available.
+    :param odoo.sql_db.Cursor cr:
+        Database cursor.
+    :param odoo.modules.registry.RegistryManager registry:
+        Database registry, using v7 api.
+    """
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    with cr.savepoint():
+        rx_state = env.ref(
+            'medical_prescription_state.prescription_order_state_unverified',
+        )
+        line_state = env.ref(
+            'medical_prescription_state.'
+            'prescription_order_line_state_unverified',
+        )
+        env['medical.prescription.order'].search([]).write({
+            'stage_id': rx_state.id,
+        })
+        env['medical.prescription.order.line'].search([]).write({
+            'stage_id': line_state.id,
+        })

--- a/medical_prescription_state/views/medical_prescription_order.xml
+++ b/medical_prescription_state/views/medical_prescription_order.xml
@@ -11,7 +11,7 @@
         <field name="name">Prescription Orders</field>
         <field name="model">medical.prescription.order</field>
         <field name="inherit_id" ref="base_kanban_stage.base_kanban_abstract_view_kanban" />
-        <field name="priority" eval="99" />
+        <field name="mode">primary</field>
         <field name="arch" type="xml">
             <xpath expr="//div[@name='card_header']">
                 <span t-if="record.patient_id.raw_value">

--- a/medical_prescription_state/views/medical_prescription_order_line.xml
+++ b/medical_prescription_state/views/medical_prescription_order_line.xml
@@ -11,7 +11,7 @@
         <field name="name">Prescription Order Lines</field>
         <field name="model">medical.prescription.order.line</field>
         <field name="inherit_id" ref="base_kanban_stage.base_kanban_abstract_view_kanban" />
-        <field name="priority" eval="99" />
+        <field name="mode">primary</field>
         <field name="arch" type="xml">
             <xpath expr="//div[@name='card_header']" position="replace">
                 <strong>


### PR DESCRIPTION
* Add default prescription and prescription line states based on US workflow

This was extracted from never released module medical_prescription_state_us. I feel that having the US workflows in core beats having nothing at all. I am unable to think of a more abstract workflow that doesn't just end up with the same thing we have here.

Depends: 
- [x] #118