### PR TITLE
[10.0][IMP] Rework Medicament, Medication, Prescription menus

### DIFF
--- a/medical_medicament/views/medical_menu.xml
+++ b/medical_medicament/views/medical_menu.xml
@@ -4,12 +4,6 @@
 
 <odoo>
 
-    <menuitem id="medicine_menu"
-              name="Medicine"
-              sequence="30"
-              parent="medical.medical_root"
-              />
-
     <menuitem id="medicaments_menu_config"
               name="Medicaments"
               parent="medical.medical_root_sub"
@@ -18,30 +12,30 @@
 
     <menuitem id="medicaments_menu"
               name="Medicaments"
-              parent="medicine_menu"
-              sequence="30"
+              parent="medicaments_menu_config"
+              sequence="10"
               action="medical_medicament_action"
+              />
+
+    <menuitem id="medical_drug_route"
+              name="Admin Routes"
+              parent="medicaments_menu_config"
+              sequence="20"
+              action="medical_drug_route_action"
               />
 
     <menuitem id="medical_medicament_component"
               name="Components"
               parent="medicaments_menu_config"
-              sequence="10"
+              sequence="30"
               action="medical_medicament_component_action"
               />
 
     <menuitem id="medical_drug_form"
-              name="Drug Form"
+              name="Forms"
               parent="medicaments_menu_config"
-              sequence="99"
+              sequence="40"
               action="medical_drug_form_action"
-              />
-    
-    <menuitem id="medical_drug_route"
-              name="Drug Admin Route"
-              parent="medicaments_menu_config"
-              sequence="98"
-              action="medical_drug_route_action"
               />
 
 </odoo>

--- a/medical_medication/views/medical_menu.xml
+++ b/medical_medication/views/medical_menu.xml
@@ -4,6 +4,12 @@
 
 <odoo>
 
+    <menuitem id="medicine_menu"
+              name="Medicine"
+              sequence="30"
+              parent="medical.medical_root"
+              />
+
     <menuitem id="medications_menu_config"
               name="Medications"
               sequence="30"
@@ -13,7 +19,7 @@
     <menuitem id="medical_medication_dosage"
               parent="medications_menu_config"
               action="medical_medication_dosage_action"
-              string="Dosages"
+              name="Dosages"
               sequence="20"
               />
 
@@ -21,14 +27,14 @@
               parent="medications_menu_config"
               sequence="10"
               action="medical_medication_template_action"
-              string="Templates"
+              name="Templates"
               />
     
     <menuitem id="medical_patient_medication_menu"
-              parent="medical_medicament.medicine_menu"
-              sequence="15"
+              parent="medicine_menu"
+              sequence="10"
               action="medical_patient_medication_action"
-              string="Medications"
+              name="Medications"
               />
 
 </odoo>

--- a/medical_prescription/views/medical_menu.xml
+++ b/medical_prescription/views/medical_menu.xml
@@ -1,27 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright 2016 LasLabs Inc.
+<!-- Copyright 2016-2017 LasLabs Inc.
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 
 <odoo>
 
-    <menuitem id="medical_prescription_root"
-              name="Prescriptions"
-              parent="medical.medical_root"
-              sequence="30" />
-
     <menuitem id="medical_prescription_order_menu"
-              sequence="10"
-              parent="medical_prescription_root"
+              parent="medical_medication.medicine_menu"
               action="medical_prescription_order_action"
-              name="Orders"
+              name="Prescription Orders"
+              sequence="20"
               />
 
-
     <menuitem id="medical_prescription_order_line_menu"
-              sequence="20"
-              parent="medical_prescription_root"
+              parent="medical_medication.medicine_menu"
               action="medical_prescription_order_line_action"
-              name="Dispensing"
+              name="Prescription Lines"
+              sequence="30"
               />
 
 </odoo>


### PR DESCRIPTION
This PR shuffles the Medicament, Medication & Prescription menus around and renames.

I think there's still a bit of work to do in the medicament config, but we're getting there.

Main motivation here was to generalize the menus a bit more. I let pharmacy influence it all a bit too much with the last redesign.