### PR TITLE
[FIX] medical_medicament_us: Fix GCN display

### DIFF
--- a/medical_medicament_us/models/medical_medicament_gcn.py
+++ b/medical_medicament_us/models/medical_medicament_gcn.py
@@ -2,7 +2,7 @@
 # © 2016 LasLabs Inc.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import models, fields
+from odoo import api, models, fields
 
 
 class MedicalMedicamentGcn(models.Model):
@@ -11,10 +11,15 @@ class MedicalMedicamentGcn(models.Model):
 
     name = fields.Char(
         string='GCN',
-        help='Generic Code Number - 5 digits',
+        help='Generic Code Number - 6 digits',
     )
     medicament_ids = fields.One2many(
         string='Medicament',
         comodel_name='medical.medicament',
         inverse_name='gcn_id',
     )
+
+    @api.multi
+    def name_get(self):
+        """ Override method to properly display the GCN """
+        return [(r.id, '%06d' % int(r.name)) for r in self]

--- a/medical_medicament_us/models/medical_medicament_gcn.py
+++ b/medical_medicament_us/models/medical_medicament_gcn.py
@@ -9,7 +9,7 @@ class MedicalMedicamentGcn(models.Model):
     _name = 'medical.medicament.gcn'
     _description = 'Medical Medicament GCN'
 
-    name = fields.Char(
+    name = fields.Integer(
         string='GCN',
         help='Generic Code Number - 6 digits',
     )
@@ -22,4 +22,4 @@ class MedicalMedicamentGcn(models.Model):
     @api.multi
     def name_get(self):
         """ Override method to properly display the GCN """
-        return [(r.id, '%06d' % int(r.name)) for r in self]
+        return [(r.id, '%06d' % r.name) for r in self]

--- a/medical_medicament_us/tests/__init__.py
+++ b/medical_medicament_us/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import test_medical_medicament
+from . import test_medical_medicament_gcn

--- a/medical_medicament_us/tests/test_medical_medicament_gcn.py
+++ b/medical_medicament_us/tests/test_medical_medicament_gcn.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp.tests.common import TransactionCase
+
+
+class TestMedicalMedicamentGcn(TransactionCase):
+
+    def setUp(self):
+        super(TestMedicalMedicamentGcn, self).setUp()
+        self.test_gcn = self.env['medical.medicament.gcn'].create({
+            'name': '123'
+        })
+
+    def test_name_get(self):
+        """ It should convert the GCN to the proper format """
+        self.assertEquals(self.test_gcn.display_name, '000123')

--- a/website_sale_medical_medicament_us/demo/medical_medicament_gcn.xml
+++ b/website_sale_medical_medicament_us/demo/medical_medicament_gcn.xml
@@ -7,6 +7,6 @@
 
 <odoo>
     <record id="acetaminophen_gcn" model="medical.medicament.gcn">
-        <field name="name">ACET</field>
+        <field name="name">18456</field>
     </record>
 </odoo>


### PR DESCRIPTION
* Add `name_get` to display GCN with prepended zero pads.