### PR TITLE
[FIX][10.0] Fixes #133 - cleans up context and adjusts view in medical_insurance

### DIFF
--- a/medical_insurance/views/medical_insurance_company_view.xml
+++ b/medical_insurance/views/medical_insurance_company_view.xml
@@ -16,9 +16,7 @@
                     <field name="parent_id" placeholder="Parent Company"
                            domain="[('is_company', '=', True)]"
                            context="{'default_is_company': True,
-                                     'default_type': 'medical.insurance.company',
-                                     'default_supplier': supplier,
-                                     'default_customer': customer}" />
+                                     'default_type': 'medical.insurance.company'}" />
                 </h3>
             </xpath>
         </field>

--- a/medical_insurance/views/medical_insurance_plan_view.xml
+++ b/medical_insurance/views/medical_insurance_plan_view.xml
@@ -29,9 +29,6 @@
                             <field name="member_exp" />
                         </group>
                         <notebook>
-                            <page string="Additional">
-                                <field name="notes" placeholder="Notes..." />
-                            </page>
                             <page string="Plan Information">
                                 <group name="plan_info">
                                     <field name="plan_number" />
@@ -39,6 +36,9 @@
                                     <field name="insurance_company_id" />
                                     <field name="insurance_affiliation" />
                                 </group>
+                            </page>
+                            <page string="Additional">
+                                <field name="notes" placeholder="Notes..." />
                             </page>
                         </notebook>
                     </sheet>


### PR DESCRIPTION
- Removes some context from medical_insurance_company_view that was causing an error
- Makes the "Plan Information" tab with all the required fields the default tab open in medical_insurance_template_view