### PR TITLE
[FIX][10.0] Fixes #147 - allows disease creation in medical_patient_disease

### DIFF
--- a/medical_patient_disease/views/medical_patient_disease_view.xml
+++ b/medical_patient_disease/views/medical_patient_disease_view.xml
@@ -159,10 +159,11 @@
                                 <field name="date_treatment_end" />
                                 <field name="is_on_treatment" />
                                 <field name="date_healed" />
+                                <field name="id" invisible="1" />
                             </group>
                         </group>
                     </group>
-                    <group name="state">
+                    <group name="state" attrs="{'invisible': [('id','=',False)]}">
                         <group name="group_validity">
                             <group>
                                 <field name="create_date" />

--- a/medical_patient_disease/views/medical_patient_disease_view.xml
+++ b/medical_patient_disease/views/medical_patient_disease_view.xml
@@ -162,7 +162,7 @@
                             </group>
                         </group>
                     </group>
-                    <group name="state" attrs="{'invisible': [('id','=',False)]}">
+                    <group name="state">
                         <group name="group_validity">
                             <group>
                                 <field name="create_date" />


### PR DESCRIPTION
Removes an attribute that was causing an error when the user tried to create a new disease.