### PR TITLE
Fixes #132 - medical_appointment: Makes date, time, and duration required

### DIFF
--- a/medical_appointment/__manifest__.py
+++ b/medical_appointment/__manifest__.py
@@ -19,6 +19,7 @@
         'security/ir.model.access.csv',
         'security/medical_security.xml',
         'data/auditlog_rule.xml',
+        'data/decimal_precision_data.xml',
         'data/medical_appointment_data.xml',
         'data/medical_appointment_sequence.xml',
     ],

--- a/medical_appointment/data/decimal_precision_data.xml
+++ b/medical_appointment/data/decimal_precision_data.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-
 <odoo>
 
-    <record forcecreate="True" id="decimal_appointment" model="decimal.precision">
+    <record id="decimal_precision_appointment" model="decimal.precision" forcecreate="True">
         <field name="name">Appointment</field>
         <field name="digits">2</field>
     </record>

--- a/medical_appointment/data/decimal_precision_data.xml
+++ b/medical_appointment/data/decimal_precision_data.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+
+<odoo>
+
+    <record forcecreate="True" id="decimal_appointment" model="decimal.precision">
+        <field name="name">Appointment</field>
+        <field name="digits">2</field>
+    </record>
+
+</odoo>

--- a/medical_appointment/data/medical_appointment_data.xml
+++ b/medical_appointment/data/medical_appointment_data.xml
@@ -85,4 +85,8 @@
 <p>Your appointment with Dr. ${object.physician_id.lastname} on ${ctx.get('appointment_date') or object.appointment_date[:10]} ${ctx.get('appointment_time') or object.appointment_date[11:]} has been confirmed.</p>
         ]]></field>
     </record>
+    <record forcecreate="True" id="decimal_appointment" model="decimal.precision">
+        <field name="name">Appointment</field>
+        <field name="digits">2</field>
+    </record>
 </odoo>

--- a/medical_appointment/data/medical_appointment_data.xml
+++ b/medical_appointment/data/medical_appointment_data.xml
@@ -85,8 +85,4 @@
 <p>Your appointment with Dr. ${object.physician_id.lastname} on ${ctx.get('appointment_date') or object.appointment_date[:10]} ${ctx.get('appointment_time') or object.appointment_date[11:]} has been confirmed.</p>
         ]]></field>
     </record>
-    <record forcecreate="True" id="decimal_appointment" model="decimal.precision">
-        <field name="name">Appointment</field>
-        <field name="digits">2</field>
-    </record>
 </odoo>

--- a/medical_appointment/models/medical_appointment.py
+++ b/medical_appointment/models/medical_appointment.py
@@ -41,7 +41,8 @@ class MedicalAppointment(models.Model):
     appointment_date = fields.Datetime(
         string='Date and Time',
         index=True,
-        help='Date and Time of Scheduled Appointment'
+        help='Date and Time of Scheduled Appointment',
+        required=True,
     )
     appointment_end_date = fields.Datetime(
         string='End Date and Time',
@@ -55,9 +56,10 @@ class MedicalAppointment(models.Model):
         help='When to stop displaying appointment',
     )
     duration = fields.Float(
-        string='Duration',
+        string='Duration (min)',
         help='Duration of appointment (in minutes)',
         default=30.0,
+        required=True,
     )
     physician_id = fields.Many2one(
         string='Physician',

--- a/medical_appointment/models/medical_appointment.py
+++ b/medical_appointment/models/medical_appointment.py
@@ -3,6 +3,7 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
 from odoo import fields, models, exceptions, api, _
+from odoo.addons import decimal_precision as dp
 from datetime import timedelta
 
 
@@ -56,10 +57,11 @@ class MedicalAppointment(models.Model):
         help='When to stop displaying appointment',
     )
     duration = fields.Float(
-        string='Duration (min)',
-        help='Duration of appointment (in minutes)',
-        default=30.0,
+        string='Duration',
+        help='Duration of appointment',
+        default=0.50,
         required=True,
+        digits=dp.get_precision('Appointment'),
     )
     physician_id = fields.Many2one(
         string='Physician',


### PR DESCRIPTION
- Makes the date/time of the appointment and the duration required fields so that they don't throw the errors noted in #132 
- Uses decimal precision in the duration