### PR TITLE
Fixes #178 - medical: removes supplier and customer from context

### DIFF
--- a/medical/views/medical_abstract_entity.xml
+++ b/medical/views/medical_abstract_entity.xml
@@ -138,8 +138,6 @@
                                          'default_state_id': state_id,
                                          'default_zip': zip,
                                          'default_country_id': country_id,
-                                         'default_supplier': supplier,
-                                         'default_customer': customer,
                                          'default_lang': lang,
                                          }">
                             <kanban>


### PR DESCRIPTION
- Removes the "supplier" and "customer" variables from where they were causing a NameError (creating a new contact/address for a patient).