### PR TITLE
[10.0][FIX] website_portal_medical_prescription_order_line: Fix text when no rx

### DIFF
--- a/website_portal_medical_prescription_order_line/views/medical_prescription_order_line_template.xml
+++ b/website_portal_medical_prescription_order_line/views/medical_prescription_order_line_template.xml
@@ -11,10 +11,10 @@
         <h3 class="page-header">
             Prescriptions
         </h3>
-        <t t-if="not patients">
+        <t t-if="not prescription_order_lines">
             <p>There are currently no prescriptions associated with your account.</p>
         </t>
-        <t t-if="patients">
+        <t t-if="prescription_order_lines">
             <h5>
                 If you would like to order a medication, please click the green
                 button to add to cart.


### PR DESCRIPTION
- Removes the option to order medications if there are no prescription lines and instead displays the message, "There are currently no prescriptions associated with your account."