### PR TITLE
[10.0][FIX] Fixes #183 - website_portal_medical_patient form

### DIFF
--- a/website_portal_medical_patient/data/ir_model_data.xml
+++ b/website_portal_medical_patient/data/ir_model_data.xml
@@ -12,6 +12,8 @@
     <function model="ir.model.fields" name="formbuilder_whitelist">
         <value>medical.patient</value>
         <value eval="[
+            'birthdate_date',
+            'gender',
             'parent_id',
             'id',
             'name',

--- a/website_portal_medical_patient/data/ir_model_data.xml
+++ b/website_portal_medical_patient/data/ir_model_data.xml
@@ -12,8 +12,6 @@
     <function model="ir.model.fields" name="formbuilder_whitelist">
         <value>medical.patient</value>
         <value eval="[
-            'birthdate_date',
-            'gender',
             'parent_id',
             'id',
             'name',
@@ -42,6 +40,8 @@
             'zip',
             'state_id',
             'country_id',
+            'birthdate_date',
+            'gender',
         ]"/>
     </function>
 


### PR DESCRIPTION
- Saves the values for gender and birthdate when a new patient is created on the website.
- When one of the values is changed, the form flashes the old value on save, but the new value is stored in the database and shown when the form is next viewed.