### PR TITLE
[FIX] website_sale_medical_prescription: Fix broken JS

### DIFF
--- a/website_sale_medical_prescription/static/src/js/field_autocomplete.js
+++ b/website_sale_medical_prescription/static/src/js/field_autocomplete.js
@@ -6,7 +6,6 @@ odoo.define('website_field_autocomplete_prescription.field_autocomplete', functi
   "use strict";
 
   var snippet_animation = require('web_editor.snippets.animation');
-  var $ = require('$');
   require('website_field_autocomplete_related.field_autocomplete');
 
   snippet_animation.registry.field_autocomplete = snippet_animation.registry.field_autocomplete.extend({

--- a/website_sale_medical_prescription/static/src/js/form_checkout.js
+++ b/website_sale_medical_prescription/static/src/js/form_checkout.js
@@ -6,7 +6,6 @@ odoo.define('website_sale_medical_prescription.form_checkout', function(require)
   "use strict";
 
   var snippet_animation = require('web_editor.snippets.animation');
-  var $ = require('$');
   
   snippet_animation.registry.medical_prescription_checkout = snippet_animation.Class.extend({
 


### PR DESCRIPTION
* Remove jQuery requires from both JS files - this is no longer provided via the import mechanism & simply exists