### PR TITLE
[IMP] medical_medicament: Remove unique from form name

### DIFF
--- a/medical_medicament/models/medical_drug_form.py
+++ b/medical_medicament/models/medical_drug_form.py
@@ -19,6 +19,5 @@ class MedicalDrugForm(models.Model):
     )
 
     _sql_constraints = [
-        ('name_uniq', 'UNIQUE(name)', 'Drug form name must be unique!'),
         ('code_uniq', 'UNIQUE(code)', 'Code should be unique!'),
     ]

--- a/medical_medicament/tests/test_medical_drug_form.py
+++ b/medical_medicament/tests/test_medical_drug_form.py
@@ -13,11 +13,6 @@ class TestMedicalDrugForm(TransactionCase):
         self.drug_form_bar = self.env.ref('medical_medicament.BAR')
         self.drug_form_capsule = self.env.ref('medical_medicament.CAP')
 
-    def test_name_unique(self):
-        """ Validate drug form unique name sql constraint """
-        with self.assertRaises(IntegrityError):
-            self.drug_form_bar.name = self.drug_form_capsule.name
-
     def test_code_unique(self):
         """ Validate drug form unique code sql constraint """
         with self.assertRaises(IntegrityError):


### PR DESCRIPTION
* Remove unique constraint from `medical.drug.form.name`. Business need may require non-unique canonical names - the billing code is what matters and needs to be unique