### PR TITLE
[10.0][FIX] medical_center: Fix wrong state_id.

### DIFF
--- a/medical_center/demo/medical_center.xml
+++ b/medical_center/demo/medical_center.xml
@@ -12,7 +12,7 @@
         <field name="country_id" ref="base.us" />
         <field name="phone">+1-888-888-8888</field>
         <field name="email">email@example.com</field>
-        <field name="state_id" ref="base.state_us_3" />
+        <field name="state_id" ref="base.state_us_23" />
     </record>
 
     <record id="medical_center_1" model="medical.center">


### PR DESCRIPTION
* This is a quick change after reviewing LABS-359.
* Most of the demo data is pretty good right now it seems, so no urgent changes needed.

* Change: arizona => nevada