### PR TITLE
[10.0][medical_center] fix error when trying to select parent company in medical center

### DIFF
--- a/medical_center/views/medical_center_view.xml
+++ b/medical_center/views/medical_center_view.xml
@@ -36,7 +36,7 @@
                 <h3>
                     <field name="is_company" invisible="True" />
                     <field name="parent_id" placeholder="Parent Company"
-                           domain="[('is_company', '=', True), ('is_center', '=', False)]"
+                           domain="[('is_company', '=', True)]"
                            context="{'default_is_company': True,
                                      'default_is_center': False,
                                      'default_supplier': supplier,


### PR DESCRIPTION
This commit fixes an error that occurs when trying to select a parent company to a medical center. The field is_center is not used anymore. It does not make sense to restrict the selection of parent company only
to partners that are not medical centers, because the parent company may just be a larger medical center.