### PR TITLE
[FIX][10.0][medical_insurance] access rules compatibility

### DIFF
--- a/medical_insurance/README.rst
+++ b/medical_insurance/README.rst
@@ -13,12 +13,12 @@ Usage
 #. Go to Medical -> Configuration -> Insurance
 #. Add a new provider by going to Insurance Providers and pressing "Create"
 #. Add or import a new plan by going to Insurance Plans and pressing "Create" or "Import"
-#. Create an insurance plan template by going to Insurance Plan Templates
-and pressing "Create" or "Import"
+#. Create an insurance plan template by going to Insurance Plan Templates and pressing "Create" or "Import"
+
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
-   :target: https://runbot.odoo-community.org/runbot/159/8.0
+   :target: https://runbot.odoo-community.org/runbot/159/10.0
 
 For further information, please visit:
 
@@ -51,6 +51,7 @@ Contributors
 * Ruchir Shukla <ruchir@techreceptives.com>
 * Parthiv Patel <parthiv@techreceptives.com>
 * Nhomar Hernandéz <nhomar@vauxoo.com>
+
 
 Maintainer
 ----------

--- a/medical_insurance/README.rst
+++ b/medical_insurance/README.rst
@@ -51,6 +51,7 @@ Contributors
 * Ruchir Shukla <ruchir@techreceptives.com>
 * Parthiv Patel <parthiv@techreceptives.com>
 * Nhomar Hernandéz <nhomar@vauxoo.com>
+* Gisela Mora <gisela.mora@eficent.com>
 
 
 Maintainer

--- a/medical_insurance/models/medical_insurance_plan.py
+++ b/medical_insurance/models/medical_insurance_plan.py
@@ -2,7 +2,7 @@
 # © 2015-TODAY LasLabs Inc.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
-from odoo import fields, models, api
+from odoo import api, fields, models
 
 
 class MedicalInsurancePlan(models.Model):
@@ -41,35 +41,23 @@ class MedicalInsurancePlan(models.Model):
         help='Additional Information',
     )
 
-    #Plan Template Information
-
     plan_number = fields.Char(
         related='insurance_template_id.plan_number',
         stored=True,
         readonly=True,
-        required=True,
-        help='Identification number for plan',
     )
     product_id = fields.Many2one(
         related='insurance_template_id.product_id',
         stored=True,
         readonly=True,
-        string='Insurance Product',
-        comodel_name='product.product',
-        required=True,
-        ondelete='cascade',
     )
     insurance_company_id = fields.Many2one(
         related='insurance_template_id.insurance_company_id',
         stored=True,
         readonly=True,
-        string='Insurance Provider',
-        comodel_name='medical.insurance.company',
-        help='Insurance Provider',
     )
     insurance_affiliation = fields.Selection(
         related='insurance_template_id.insurance_affiliation',
         stored=True,
         readonly=True,
-        help='What type of entity is this insurance provided to?'
     )

--- a/medical_insurance/models/medical_insurance_plan.py
+++ b/medical_insurance/models/medical_insurance_plan.py
@@ -2,13 +2,19 @@
 # © 2015-TODAY LasLabs Inc.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
-from odoo import fields, models
+from odoo import fields, models, api
 
 
 class MedicalInsurancePlan(models.Model):
     _name = 'medical.insurance.plan'
     _description = 'Medical Insurance Providers'
-    _inherits = {'medical.insurance.template': 'insurance_template_id', }
+
+    name = fields.Char(
+        related='insurance_template_id.name',
+        stored=True,
+        readonly=True,
+        required=False,
+    )
     insurance_template_id = fields.Many2one(
         string='Plan Template',
         comodel_name='medical.insurance.template',
@@ -29,4 +35,41 @@ class MedicalInsurancePlan(models.Model):
     )
     member_exp = fields.Date(
         string='Expiration Date',
+    )
+    notes = fields.Text(
+        string='Extra Info',
+        help='Additional Information',
+    )
+
+    #Plan Template Information
+
+    plan_number = fields.Char(
+        related='insurance_template_id.plan_number',
+        stored=True,
+        readonly=True,
+        required=True,
+        help='Identification number for plan',
+    )
+    product_id = fields.Many2one(
+        related='insurance_template_id.product_id',
+        stored=True,
+        readonly=True,
+        string='Insurance Product',
+        comodel_name='product.product',
+        required=True,
+        ondelete='cascade',
+    )
+    insurance_company_id = fields.Many2one(
+        related='insurance_template_id.insurance_company_id',
+        stored=True,
+        readonly=True,
+        string='Insurance Provider',
+        comodel_name='medical.insurance.company',
+        help='Insurance Provider',
+    )
+    insurance_affiliation = fields.Selection(
+        related='insurance_template_id.insurance_affiliation',
+        stored=True,
+        readonly=True,
+        help='What type of entity is this insurance provided to?'
     )

--- a/medical_insurance/models/medical_insurance_plan.py
+++ b/medical_insurance/models/medical_insurance_plan.py
@@ -2,7 +2,7 @@
 # © 2015-TODAY LasLabs Inc.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
-from odoo import api, fields, models
+from odoo import fields, models
 
 
 class MedicalInsurancePlan(models.Model):

--- a/medical_insurance/tests/test_medical_insurance_company.py
+++ b/medical_insurance/tests/test_medical_insurance_company.py
@@ -2,7 +2,7 @@
 # Copyright 2016 LasLabs Inc.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
-from openerp.tests.common import TransactionCase
+from odoo.tests.common import TransactionCase
 
 
 class TestMedicalInsuranceCompany(TransactionCase):

--- a/medical_insurance/views/medical_insurance_plan_view.xml
+++ b/medical_insurance/views/medical_insurance_plan_view.xml
@@ -6,9 +6,9 @@
             <field name="model">medical.insurance.plan</field>
             <field name="arch" type="xml">
                 <tree string="Insurance Plans">
+                    <field name="name" />
                     <field name="patient_id" />
                     <field name="number" />
-                    <field name="name" />
                     <field name="insurance_company_id" />
                     <field name="insurance_template_id" />
                 </tree>
@@ -22,6 +22,9 @@
                 <form string="Insurance Plan">
                     <header />
                     <sheet>
+                        <h2>
+                            <field name="name" nolabel="1" />
+                        </h2>
                         <group name="data">
                             <field name="patient_id" />
                             <field name="number" />
@@ -31,14 +34,16 @@
                         <notebook>
                             <page string="Plan Information">
                                 <group name="plan_info">
-                                    <field name="plan_number" />
-                                    <field name="product_id" />
-                                    <field name="insurance_company_id" />
-                                    <field name="insurance_affiliation" />
+                                    <field name="insurance_template_id" />
+                                    <field name="plan_number"/>
+                                    <field name="product_id"/>
+                                    <field name="insurance_company_id"/>
+                                    <field name="insurance_affiliation"/>
                                 </group>
                             </page>
                             <page string="Additional">
-                                <field name="notes" placeholder="Notes..." />
+                                <field name="notes" readonly="1"
+                                       placeholder="Notes..." />
                             </page>
                         </notebook>
                     </sheet>
@@ -55,7 +60,6 @@
                     <field name="name" />
                     <field name="patient_id" />
                     <field name="number" />
-                    <field name="is_default" />
                     <field name="insurance_company_id" />
                     <field name="insurance_template_id" />
                     <field name="notes" />
@@ -63,9 +67,6 @@
                     <field name="product_id" />
                     <newline />
                     <group expand="0" string="Group By...">
-                        <filter string="Default plan"
-                                domain="[]"
-                                context="{'group_by':'is_default'}" />
                         <filter string="Insurance Company"
                                 domain="[]"
                                 context="{'group_by':'insurance_company_id'}" />

--- a/medical_insurance/views/medical_insurance_plan_view.xml
+++ b/medical_insurance/views/medical_insurance_plan_view.xml
@@ -42,8 +42,7 @@
                                 </group>
                             </page>
                             <page string="Additional">
-                                <field name="notes" readonly="1"
-                                       placeholder="Notes..." />
+                                <field name="notes" placeholder="Notes..." />
                             </page>
                         </notebook>
                     </sheet>


### PR DESCRIPTION
Eliminates the '_inherits' in order to be able to set different access rules for 'medical.insurance.template' and 'medical.insurance.plan'.