### PR TITLE
[10.0][medical_center] fix use of default_image

### DIFF
--- a/medical_center/models/medical_center.py
+++ b/medical_center/models/medical_center.py
@@ -19,7 +19,7 @@ class MedicalCenter(models.Model):
         })
         return super(MedicalCenter, self)._create_vals(vals)
 
-    @api.model
+    @api.model_cr_context
     def _get_default_image_path(self, vals):
         super(MedicalCenter, self)._get_default_image_path(vals)
         return get_module_resource(

--- a/medical_center/tests/test_medical_center.py
+++ b/medical_center/tests/test_medical_center.py
@@ -34,3 +34,24 @@ class TestMedicalCenter(TransactionCase):
         self.assertFalse(
             self.partner_center_1.customer,
         )
+
+    def test_create_vals_get_default_image_encoded(self):
+        """ It should get the default image for entity on create. """
+        Center = self.env['medical.center'].with_context(
+            __image_create_allow=True,
+        )
+        vals = {'name': 'test'}
+        center = Center.create(vals)
+        self.assertTrue(center.image)
+
+    def test_get_default_image_encoded(self):
+        """ It should return the default image for the entity. """
+        Center = self.env['medical.center']
+        image = Center._get_default_image_encoded({})
+        self.assertTrue(image)
+
+    def test_allow_image_create_no_test(self):
+        """ It should not perform default image manipulation when testing. """
+        Center = self.env['medical.center']
+        can_create = Center._allow_image_create({})
+        self.assertFalse(can_create)

--- a/medical_center/views/medical_center.xml
+++ b/medical_center/views/medical_center.xml
@@ -36,7 +36,7 @@
                 <h3>
                     <field name="is_company" invisible="True" />
                     <field name="parent_id" placeholder="Parent Company"
-                           domain="[('is_company', '=', True), ('is_center', '=', False)]"
+                           domain="[('is_company', '=', True)]"
                            context="{'default_is_company': True,
                                      'default_is_center': False,
                                      'default_supplier': supplier,


### PR DESCRIPTION
This PR contains fixes on the use of the methods to get the default image on the center, and adds supporting tests.

Please rebase LasLabs/10.0-mig-medical_center with OCA/10.0 before this PR can be merged.