### PR TITLE
[FIX] medical_medicament_us: Add missing dependency

### DIFF
--- a/medical_medicament_us/__manifest__.py
+++ b/medical_medicament_us/__manifest__.py
@@ -11,6 +11,7 @@
     'depends': [
         'medical_base_us',
         'medical_medication',
+        'medical_manufacturer',
     ],
     'website': 'https://laslabs.com',
     'license': 'AGPL-3',


### PR DESCRIPTION
* medical.medicament.ndc relates to medical.manufacturer, which does not exist without it defined as a dependency.