### PR TITLE
[FIX] medical_prescription: Images should be attachments

### DIFF
--- a/medical_prescription/models/medical_prescription_order.py
+++ b/medical_prescription/models/medical_prescription_order.py
@@ -53,16 +53,19 @@ class MedicalPrescriptionOrder(models.Model):
     )
     image = fields.Binary(
         help='Full sized image of the original prescription order.',
+        attachment=True,
     )
     image_medium = fields.Binary(
         help='Medium sized image of the original prescription order.',
         compute='_compute_images',
         store=True,
+        attachment=True,
     )
     image_small = fields.Binary(
         help='Small sized image of the original prescription order.',
         compute='_compute_images',
         store=True,
+        attachment=True,
     )
 
     @api.multi


### PR DESCRIPTION
* Change prescription order images to be attachments for greater usability