### PR TITLE
[10.0][FIX] Portal Patient URIs

### DIFF
--- a/website_portal_medical_patient/models/medical_patient.py
+++ b/website_portal_medical_patient/models/medical_patient.py
@@ -17,7 +17,7 @@ class MedicalPatient(models.Model):
     @api.multi
     def _compute_website_url(self):
         for record in self:
-            record.website_url = "/medical/patients/%s" % (record.id)
+            record.website_url = "/medical/patient/%s" % (record.id)
 
     @api.model
     def search_related_patients(self):

--- a/website_portal_medical_patient/security/ir.model.access.csv
+++ b/website_portal_medical_patient/security/ir.model.access.csv
@@ -2,5 +2,6 @@ id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_medical_patient_portal,medical.patient.portal,medical.model_medical_patient,base.group_portal,1,1,1,0
 access_res_partner_portal,res.partner.portal,base.model_res_partner,base.group_portal,1,1,1,0
 access_product_uom_portal,product.uom.portal,product.model_product_uom,base.group_portal,1,1,0,0
+access_product_uom_categ_portal,product.uom.categ.portal,product.model_product_uom_categ,base.group_portal,1,1,0,0
 access_product_pricelist_portal,product.pricelist.portal,product.model_product_pricelist,base.group_portal,1,1,0,0
 access_medical_patient_disease_portal,access.medical.patient.disease.portal,medical_patient_disease.model_medical_patient_disease,base.group_portal,1,1,0,0

--- a/website_portal_medical_patient/static/src/js/website_portal_medical_patient_tour.js
+++ b/website_portal_medical_patient/static/src/js/website_portal_medical_patient_tour.js
@@ -23,7 +23,7 @@
             },
             {
                 content: _t('Click on Emma Fields'),
-                trigger: "a[href='/medical/patients/1']"
+                trigger: "a[href='/medical/patient/1']"
             },
             {
                 content: _t('Change Full Name'),

--- a/website_portal_medical_patient/tests/test_medical_patient.py
+++ b/website_portal_medical_patient/tests/test_medical_patient.py
@@ -21,7 +21,7 @@ class TestMedicalPatient(TransactionCase):
         """ Test website_url returns correct id """
         self.assertEquals(
             self.patient_1.website_url,
-            '/medical/patients/%s' % self.patient_1.id,
+            '/medical/patient/%s' % self.patient_1.id,
         )
 
     def test_search_related_patients(self):

--- a/website_portal_medical_patient/views/patients_template.xml
+++ b/website_portal_medical_patient/views/patients_template.xml
@@ -6,10 +6,12 @@
 
     <template id="medical_my_patients" name="My Patients">
         <t t-call="website_portal_medical.medical_layout">
-            <h3 class="page-header">Your Patients</h3>
-            <t t-if="not patients">
-                <p>There are currently no patients for your account.</p>
-            </t>
+            <h3 class="page-header medical-header">
+                Patients
+                <a href="/medical/patient" class="pull-right btn-lg text-uppercase add-plan">
+                    Add
+                </a>
+            </h3>
             <t t-if="patients">
                 <div class="row">
                     <t t-foreach="patients" t-as="patient">
@@ -26,6 +28,9 @@
                         </div>
                     </t>
                 </div>
+            </t>
+            <t t-else="">
+                <p>There are currently no patients associated with your account.</p>
             </t>
         </t>
     </template>

--- a/website_portal_medical_patient/views/website_medical_template.xml
+++ b/website_portal_medical_patient/views/website_medical_template.xml
@@ -17,10 +17,10 @@
             <h3 class="page-header">
                 <a href="/medical/patients">Your Patients
                     <small class="ml8">
-                        <t t-if="patient_count">
-                            <span class='badge'><t t-esc="patient_count" /></span>
+                        <t t-if="patients">
+                            <span class='badge'><t t-esc="len(patients)" /></span>
                         </t>
-                        <t t-if="not patient_count">
+                        <t t-else="">
                             There are currently no patients for your account.
                         </t>
                     </small>

--- a/website_portal_medical_patient_species/static/src/js/website_patient_form_tour.js
+++ b/website_portal_medical_patient_species/static/src/js/website_patient_form_tour.js
@@ -23,7 +23,7 @@
             },
             {
                 content: _t('Click on Emma Fields'),
-                trigger: "a[href='/medical/patients/1']"
+                trigger: "a[href='/medical/patient/1']"
             },
             {
                 content: _t('Change Species'),


### PR DESCRIPTION
### Overview
* Change uris to `/medical/patients`, `/medical/patient`, and `/medical/patient/<int:patient_id>`
* Add product.uom.categ access for portal user
* Some minor fixes to xml views
* Add ability to create patients in website (was accidentally removed)
* Pass patients object to `/my/medical` view instead of the length of records (length done in xml)