### PR TITLE
[ADD] sale_medical_prescription: Add Prescription Line smart button to Sale Order

### DIFF
--- a/sale_medical_prescription/models/medical_prescription_order_line.py
+++ b/sale_medical_prescription/models/medical_prescription_order_line.py
@@ -18,6 +18,7 @@ class MedicalPrescriptionOrderLine(models.Model):
         string='Sale Orders',
         comodel_name='sale.order',
         compute='_compute_orders',
+        store=True,
         readonly=True,
     )
     verify_method = fields.Selection(
@@ -37,6 +38,7 @@ class MedicalPrescriptionOrderLine(models.Model):
     )
 
     @api.multi
+    @api.depends('sale_order_line_ids')
     def _compute_orders(self):
         for record in self:
             order_ids = []

--- a/sale_medical_prescription/models/sale_order.py
+++ b/sale_medical_prescription/models/sale_order.py
@@ -24,6 +24,11 @@ class SaleOrder(models.Model):
         compute='_compute_prescription_order_ids',
         readonly=True,
     )
+    prescription_order_line_count = fields.Integer(
+        string='Prescription Line Count',
+        compute='_compute_prescription_order_ids',
+        readonly=True,
+    )
     prescription_order_line_ids = fields.Many2many(
         string='Prescription Lines',
         comodel_name='medical.prescription.order.line',
@@ -64,3 +69,4 @@ class SaleOrder(models.Model):
 
             record.prescription_order_ids = rx_orders
             record.prescription_order_line_ids = rx_lines
+            record.prescription_order_line_count = len(rx_lines)

--- a/sale_medical_prescription/tests/test_sale_order.py
+++ b/sale_medical_prescription/tests/test_sale_order.py
@@ -41,3 +41,12 @@ class TestSaleOrder(TransactionCase):
         self.assertEqual(
             res, exp,
         )
+
+    def test_compute_prescription_order_line_count(self):
+        """ Test rx line count properly computed """
+        exp = self.sale_7.order_line.mapped('prescription_order_line_id').ids
+        exp = len(exp)
+        res = len(self.sale_7.prescription_order_line_ids.ids)
+        self.assertEqual(
+            res, exp,
+        )

--- a/sale_medical_prescription/views/sale_order_view.xml
+++ b/sale_medical_prescription/views/sale_order_view.xml
@@ -11,7 +11,7 @@
         <field name="arch" type="xml">
             <xpath expr="//button[@name='action_view_invoice']" position="before">
                 <button type="action" class="oe_stat_button" icon="fa-list"
-                        name="%(medical_prescription.medical_prescription_order_line_action)d"
+                        name="medical_prescription.medical_prescription_order_line_action"
                         attrs="{'invisible': [('prescription_order_line_count', '=', 0)]}"
                         context="{'search_default_sale_order_ids': name}">
                     <field name="prescription_order_line_count"

--- a/sale_medical_prescription/views/sale_order_view.xml
+++ b/sale_medical_prescription/views/sale_order_view.xml
@@ -9,6 +9,15 @@
         <field name="model">sale.order</field>
         <field name='inherit_id' ref='sale.view_order_form' />
         <field name="arch" type="xml">
+            <xpath expr="//button[@name='action_view_invoice']" position="before">
+                <button type="action" class="oe_stat_button" icon="fa-list"
+                        name="%(medical_prescription.medical_prescription_order_line_action)d"
+                        attrs="{'invisible': [('prescription_order_line_count', '=', 0)]}"
+                        context="{'search_default_sale_order_ids': name}">
+                    <field name="prescription_order_line_count"
+                           widget="statinfo" string="Rx Lines"/>
+                </button>
+            </xpath>
             <xpath expr="//field[@name='partner_id']" position="after">
                 <field name="patient_ids" invisible="True" />
             </xpath>


### PR DESCRIPTION
Adds a smart button with a count of prescription lines to sale orders. Links to prescription lines belonging to that sale order.

Also fixes the previously non-functional Sale Order search on prescription lines.

![screen shot 2017-10-02 at 5 51 32 pm](https://user-images.githubusercontent.com/20194487/31105634-8582e3f2-a79a-11e7-97be-cd2f0d972853.png)

- [x] Test for the prescription_order_line_count calculation