### PR TITLE
[FIX] medical_prescription_us: Missing depend

### DIFF
--- a/medical_prescription_us/__manifest__.py
+++ b/medical_prescription_us/__manifest__.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
-# © 2016 LasLabs Inc.
+# Copyright 2016-2017 LasLabs Inc.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {
     'name': 'Medical Prescription - US Locale',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'author': "LasLabs, Odoo Community Association (OCA)",
     'category': 'Medical',
     'depends': [
-        'medical_base_us',
+        'medical_medicament_us',
         'medical_prescription',
     ],
     "website": "https://laslabs.com",


### PR DESCRIPTION
* Add missing dependency on ``medical_medicament_us`` and remove ``medical_base_us`` dependency made redundant by this change