### PR TITLE
[FIX] sale_stock_medical_prescription: dispense_qty

### DIFF
--- a/sale_stock_medical_prescription/models/sale_order_line.py
+++ b/sale_stock_medical_prescription/models/sale_order_line.py
@@ -19,7 +19,11 @@ class SaleOrderLine(models.Model):
     )
 
     @api.multi
-    @api.depends('product_uom', 'prescription_order_line_id.dispense_uom_id')
+    @api.depends(
+        'product_uom',
+        'product_uom_qty',
+        'prescription_order_line_id.dispense_uom_id',
+    )
     def _compute_dispense_qty(self):
         for record in self:
             rx_line = record.prescription_order_line_id

--- a/sale_stock_medical_prescription/tests/test_sale_order_line.py
+++ b/sale_stock_medical_prescription/tests/test_sale_order_line.py
@@ -95,9 +95,8 @@ class TestSaleOrderLine(TransactionCase):
 
     def test_check_can_dispense_qty_greater_than_rx_line_can_dispense(self):
         """ Test raise ValidationError if try dispense but not enough stock """
-        self.order_line_13.product_uom_qty = 1000
         with self.assertRaises(ValidationError):
-            self.order_line_13._check_can_dispense()
+            self.order_line_13.product_uom_qty = 1000
 
     def test_prepare_order_line_procurement_otc(self):
         """ It should not throw an error and should assign OTC route """


### PR DESCRIPTION
* Update ``depends`` on computed ``sale.order.line`` field ``dispense_qty`` so that it is correctly recomputed when a prescription sale order line's quantity changes
* Update unit test accordingly